### PR TITLE
templates: set minimum required CMake version to 3.5

### DIFF
--- a/templates/addon/CMakeLists.txt.j2
+++ b/templates/addon/CMakeLists.txt.j2
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project({{ game.addon }})
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})

--- a/templates/addon/depends/common/{{ game.name }}/CMakeLists.txt.j2
+++ b/templates/addon/depends/common/{{ game.name }}/CMakeLists.txt.j2
@@ -1,5 +1,5 @@
 {% if not makefile.cmake %}
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project({{ game.name }})
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})

--- a/templates/addon/depends/windows/mingw/CMakeLists.txt.j2
+++ b/templates/addon/depends/windows/mingw/CMakeLists.txt.j2
@@ -1,6 +1,5 @@
 {% if not makefile.cmake %}
-cmake_minimum_required(VERSION 3.4)
-
+cmake_minimum_required(VERSION 3.5)
 project(mingw)
 
 foreach(repo msys mingw32 mingw64)

--- a/tests/integration/test_data/test_libretro_ctypes/CMakeLists.txt
+++ b/tests/integration/test_data/test_libretro_ctypes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(libretro_test LANGUAGES C)
 
 add_library(${PROJECT_NAME} SHARED libretro.c)

--- a/tests/integration/test_data/test_template_processor/addon/CMakeLists.txt
+++ b/tests/integration/test_data/test_template_processor/addon/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(game.libretro.mygame)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})

--- a/tests/integration/test_data/test_template_processor/addon/depends/common/mygame/CMakeLists.txt
+++ b/tests/integration/test_data/test_template_processor/addon/depends/common/mygame/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(mygame)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})

--- a/tests/integration/test_data/test_template_processor/addon/depends/windows/mingw/CMakeLists.txt
+++ b/tests/integration/test_data/test_template_processor/addon/depends/windows/mingw/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
-
+cmake_minimum_required(VERSION 3.5)
 project(mingw)
 
 foreach(repo msys mingw32 mingw64)


### PR DESCRIPTION
https://github.com/xbmc/xbmc/pull/16458 needs a minimum of version of 3.3.
Ubuntu Xenial (16.04) provides CMake 3.5.1 (https://packages.ubuntu.com/xenial/cmake).