### PR TITLE
Add missing keyrings.alt dependency to requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,10 @@
 gitpython
 jinja2
 keyring
+# Without the following, some users get:
+# ``ModuleNotFoundError: No module named 'keyring.util.escape'``
+#
+# See https://github.com/dcos/dcos-e2e/issues/1643.
+keyrings.alt
 PyGithub>=1.43.2
 xmljson


### PR DESCRIPTION
When missing, this caused the following error:

```
ModuleNotFoundError: No module named 'keyring.util.escape'
Error initializing plugin EntryPoint(name='pyfs', value='keyrings.alt.pyfs', group='keyring.backends').
```

After `pip3 install -r requirements.txt`, the script ran successfully.

Borrowed from: https://github.com/dcos/dcos-e2e/pull/1812
