### PR TITLE
Use libretro author if available

### DIFF
--- a/templates/addon/{{ game.addon }}/addon.xml.in.j2
+++ b/templates/addon/{{ game.addon }}/addon.xml.in.j2
@@ -3,7 +3,7 @@
 	{% set addon_name = libretro_info.display_name | default(xml.addon.name) | default(system_info.name) | default(game.name) %}
 		name="{{ addon_name | e }}"
 		version="{{ game.version | default(xml.addon.version) | default('0.0.0') }}"
-		provider-name="Libretro">
+		provider-name="{{ libretro_info.authors | default('Libretro') }}">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
 		{% for addon in xml.addon.requires.import | default([]) | get_list %}


### PR DESCRIPTION
If a libretro author is available, use that instead of "Libretro".

Example update: https://github.com/kodi-game/game.libretro.bluemsx/commit/testing