### PR TITLE
config: Rename 4DO to Opera

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -27,7 +27,6 @@ GITHUB_ADDON_PREFIX = 'game.libretro.'
 # core: {(Libretro repo, Makefile, Directory)}
 ADDONS = {
     '2048':                      ('libretro-2048',              'Makefile.libretro', '.',                 'jni', {}),
-    '4do':                       ('4do-libretro',               'Makefile',          '.',                 'jni', {}),
     'beetle-bsnes':              ('beetle-bsnes-libretro',      'Makefile',          '.',                 'jni', {'soname': 'mednafen_snes'}),
     'beetle-gba':                ('beetle-gba-libretro',        'Makefile',          '.',                 'jni', {'soname': 'mednafen_gba'}),
     'beetle-lynx':               ('beetle-lynx-libretro',       'Makefile',          '.',                 'jni', {'soname': 'mednafen_lynx'}),
@@ -79,6 +78,7 @@ ADDONS = {
     'nestopia':                  ('nestopia',                   'Makefile',          'libretro',          'libretro/jni', {}),
     'nx':                        ('nxengine-libretro',          'Makefile',          '.',                 'jni', {'soname': 'nxengine'}),
     'o2em':                      ('libretro-o2em',              'Makefile',          '.',                 'jni', {}),
+    'opera':                     ('opera-libretro',             'Makefile',          '.',                 'jni', {}),
     'parallel_n64':              ('parallel-n64',               'Makefile',          '.',                 'jni', {}),
     'pcem':                      ('libretro-pcem',              'Makefile.libretro', 'src',               'jni', {}),
     'pcsx-rearmed':              ('pcsx_rearmed',               'Makefile.libretro', '.',                 'jni', {'soname': 'pcsx_rearmed'}),


### PR DESCRIPTION
Noticed the following error in the build log:

```
-- Install configuration: "Release"
CMake Error at cmake_install.cmake:49 (file):
  file INSTALL cannot find
  "/home/garrett/Documents/kodi-game-scripting/game-addons/build/build/4do/src/4do/./4do_libretro.so".
```

Further inspection leads to https://github.com/libretro/opera-libretro/pull/139.

Result: https://github.com/kodi-game/game.libretro.opera/commit/0a47255d42f1a2b44ec6b877c4ac6a61890f258a