### PR TITLE
Replace | with , in libretro author list

### DIFF
--- a/templates/addon/{{ game.addon }}/addon.xml.in.j2
+++ b/templates/addon/{{ game.addon }}/addon.xml.in.j2
@@ -3,7 +3,7 @@
 	{% set addon_name = libretro_info.display_name | default(xml.addon.name) | default(system_info.name) | default(game.name) %}
 		name="{{ addon_name | e }}"
 		version="{{ game.version | default(xml.addon.version) | default('0.0.0') }}"
-		provider-name="{{ libretro_info.authors | default('Libretro') }}">
+		provider-name="{{ libretro_info.authors | default('Libretro') | replace('|', ', ')}}">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
 		{% for addon in xml.addon.requires.import | default([]) | get_list %}


### PR DESCRIPTION
## Description

Follow up to https://github.com/kodi-game/kodi-game-scripting/pull/72. Author strings can look like:

```
provider-name="Guillaume Duhammel|Theo Berkau|Anders Montonen">
```

After this change, they look like:

```
provider-name="Guillaume Duhammel, Theo Berkau, Anders Montonen">
```

## How has this been tested?

See https://github.com/kodi-game/game.libretro.yabause/commit/66b4031c76c5cc1a525c4220210022378fa3daba