### PR TITLE
Add Mupen64Plus-Next to config

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -74,7 +74,7 @@ ADDONS = {
     'meteor':                    ('meteor-libretro',            'Makefile',          'libretro',          'libretro/jni', {}),
     'mgba':                      ('mgba',                       'Makefile',          '.',                 'jni', {}),
     'mrboom':                    ('mrboom-libretro',            'Makefile',          '.',                 'jni', {}),
-    #'mupen64plus':               ('mupen64plus-libretro',       'Makefile',          '.',                 'jni', {}),
+    'mupen64plus-nx':            ('mupen64plus-libretro-nx',    'Makefile',          '.',                 'jni', {'soname': 'mupen64plus_next'}),
     'nestopia':                  ('nestopia',                   'Makefile',          'libretro',          'libretro/jni', {}),
     'nx':                        ('nxengine-libretro',          'Makefile',          '.',                 'jni', {'soname': 'nxengine'}),
     'o2em':                      ('libretro-o2em',              'Makefile',          '.',                 'jni', {}),


### PR DESCRIPTION
## Description

Mupen64Plus was forked. The new repo is https://github.com/libretro/mupen64plus-libretro-nx

I renamed the game.libretro.mupen64plus repo to create a 302 redirect. I renamed the files and folders so that subsequent kodi-game-scripting updates would modify the correct files.

After that, I pointed kodi-game-scripting at the repo, and checked the results.

## How has this been tested?

Successful update by kodi-game-scripting running in an azure pipeline: https://github.com/kodi-game/game.libretro.mupen64plus-nx/commits/master

(build time was about 3 mins)