### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/.azure/azure-process-addon.yml
+++ b/.azure/azure-process-addon.yml
@@ -1,0 +1,11 @@
+parameters:
+  addons : []
+
+steps:
+  - ${{ each addon in parameters.addons }}:
+    - script: |
+        ./process_game_addons.py --game-addons-dir="game-addons" --kodi-source-dir="$(pwd)/kodi" --git --compile --push-branch="master" --filter="${{ addon }}$"
+      displayName: 'Process ${{ addon }}'
+      continueOnError: true
+      env:
+        GITHUB_ACCESS_TOKEN: $(GITHUB_ACCESS_TOKEN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,319 @@
+################################################################################
+#
+# Pipeline to process Kodi game -addons
+#
+################################################################################
+
+#
+# Parameters:
+#
+#   Secret files:
+#     * privateKey - the SSH private key used to push to kodi-game repos
+#
+#   Git authorship:
+#     * TODO: Parameterize git authorship
+#
+
+# TODO: Run as a cron job
+trigger:
+- todo-disabled-for-now
+
+jobs:
+  - job: Build
+
+    pool:
+      vmImage: 'ubuntu-20.04'
+
+    strategy:
+        matrix:
+          Python310:
+            python.version: '3.10'
+
+    timeoutInMinutes: 0 # Use the maximum limit
+
+    steps:
+    # Download secure file to the agent machine
+    - task: DownloadSecureFile@1
+      name: privateKey # The name with which to reference the secure file's path on the agent
+      displayName: 'Download SSH private key'
+      inputs:
+        secureFile: 'id_rsa-azure' # The file name or GUID of the secure file
+
+    # Install SSH key prior to a build or deployment
+    - task: InstallSSHKey@0
+      inputs:
+        knownHostsEntry: "|1|5qWKb7xAKkWXfLw6ZdNAs9FzKNA=|A+W82x1iZWz+nXHgPdlIQmsEOsU= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+        sshKeySecureFile: 'id_rsa-azure'
+
+    - script: |
+        sudo apt update
+        #
+        # craft
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # desmume
+        #
+        dpkg -s libpcap-dev || sudo apt install -y libpcap-dev
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # dolphin
+        #
+        dpkg -s libegl1-mesa-dev || sudo apt install libegl1-mesa-dev
+        dpkg -s libusb-1.0-0-dev || sudo apt install -y libusb-1.0-0-dev
+        dpkg -s libxi-dev || sudo apt install -y libxi-dev
+        dpkg -s libxrandr-dev || sudo apt install -y libxrandr-dev
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # dosbox-core
+        #
+        dpkg -s libasound2-dev || sudo apt install -y libasound2-dev
+        dpkg -s libtool-bin || sudo apt install -y libtool-bin
+        dpkg -s ninja-build || sudo apt install -y ninja-build
+        #
+        # flycast
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # fsuae
+        #
+        dpkg -s libglib2.0-dev || sudo apt install -y libglib2.0-dev
+        dpkg -s libmpeg2-4-dev || sudo apt install -y libmpeg2-4-dev
+        #
+        # fuse
+        #
+        #dpkg -s libglib2.0-dev || sudo apt install -y libglib2.0-dev
+        #
+        # hbmame
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # lrps2
+        #
+        dpkg -s ccache || sudo apt install -y ccache
+        dpkg -s libaio-dev || sudo apt install -y libaio-dev
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # mame
+        #
+        dpkg -s libasound2-dev || sudo apt install -y libasound2-dev
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # mame2016
+        #
+        dpkg -s libasound2-dev || sudo apt install -y libasound2-dev
+        #
+        # melonds
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # mupen64plus-nx
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        dpkg -s nasm || sudo apt install -y nasm
+        #
+        # parallel_n64
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        dpkg -s nasm || sudo apt install -y nasm
+        #
+        # parallext
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        dpkg -s nasm || sudo apt install -y nasm
+        #
+        # ppsspp
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # same_cdi
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # vecx
+        #
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
+        #
+        # wolfenstein3d
+        #
+        #dpkg -s libsdl1.2-dev || sudo apt install -y libsdl1.2-dev
+      displayName: 'Install system dependencies'
+
+    # TODO: git authorship
+    - script: |
+        git config --global user.name "Garrett Brown"
+        git config --global user.email "themagnificentmrb@gmail.com"
+      displayName: 'Set Git authorship'
+
+    - script: |
+        git clone --branch retroplayer-20 --depth=1 https://github.com/garbear/xbmc.git kodi
+      displayName: 'Clone Kodi'
+
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: $(python.version)
+
+    - script: |
+        pip3 install -r requirements.txt
+      displayName: 'Install Python requirements'
+
+    - template: .azure/azure-process-addon.yml
+      parameters:
+        # List add-ons in reverse order for sorted results in the kodi-game org
+        addons:
+          - yabause
+          - xrick
+          - xmil
+          #- wolfenstein3d # Doesn't compile
+          - virtualjaguar
+          #- vice # Problem with settings
+          - vemulator
+          - vecx
+          - vbam
+          - vba-next
+          - uzem
+          #- uae4arm # Doesn't run on x86_64
+          #- uae # Problem with settings
+          - tyrquake
+          - thepowdertoy
+          - theodore
+          - tgbdual
+          - swanstation
+          - supafaust
+          - stella
+          - snes9x2010
+          - snes9x2002
+          - snes9x
+          - smsplus-gx
+          - scummvm
+          - sameboy
+          - same_cdi
+          #- rustation # Disabled for now
+          - retro8
+          - remotejoy
+          - reminiscence
+          - redbook
+          - race
+          - quicknes
+          - quasi88
+          - px68k
+          - prosystem
+          - prboom
+          - ppsspp
+          - potator
+          - pokemini
+          - pocketcdg
+          - picodrive
+          - pcsx-rearmed
+          - pcem
+          - parallext
+          - parallel_n64
+          - opera
+          - openlara
+          - oberon
+          - o2em
+          - nx
+          - nestopia
+          - neocd
+          - mupen64plus-nx
+          - mu
+          #- mrboom # Problem with settings
+          - mgba
+          - meteor
+          - mesen-s
+          - mesen
+          - meowpc98
+          - melonds
+          - mame2016
+          - mame2015
+          - mame2010
+          - mame2003_plus
+          - mame2003_midway
+          - mame2003
+          - mame2000
+          #- mame # Insanely huge and long running (hours and 50GB on a fast machine)
+          - lutro
+          - lrps2
+          - hbmame
+          - hatari
+          - handy
+          - gw
+          - gpsp
+          - gong
+          - genplus-wide
+          - genplus
+          - gearboy
+          - gambatte
+          - galaxy
+          - fuse
+          #- fsuae # Requires configure command: "./autogen.sh && ./configure && make gen"
+          - frodo
+          - freeintv
+          - freechaf
+          - fmsx
+          - flycast
+          - fceumm
+          - fbneo
+          - fbalpha2012-neogeo
+          - fbalpha2012-cps3
+          - fbalpha2012-cps2
+          - fbalpha2012-cps1
+          - fbalpha2012
+          - ep128emu
+          - ecwolf
+          - dosbox-pure
+          - dosbox-core
+          - dosbox
+          - dolphin
+          - dinothawr
+          - desmume2015
+          - desmume
+          - daphne
+          - crocods
+          - craft
+          - chailove
+          - cap32
+          - cannonball
+          - bsnes2014-performance
+          - bsnes2014-balanced
+          - bsnes2014-accuracy
+          - bsnes-mercury-performance
+          - bsnes-mercury-balanced
+          - bsnes-mercury-accuracy
+          - boom3
+          - bnes
+          - bluemsx
+          - blastem
+          - bk
+          - beetle-wswan
+          - beetle-vb
+          - beetle-supergrafx
+          - beetle-saturn
+          - beetle-psx
+          - beetle-pcfx
+          - beetle-pce-fast
+          - beetle-pce
+          - beetle-ngp
+          - beetle-lynx
+          - beetle-gba
+          - beetle-bsnes
+          - atari800
+          - 81
+          - 3dengine
+          - 2048
+
+    - script: |
+        echo
+        echo "wiki.txt:"
+        echo
+        cat game-addons/wiki.txt
+        echo
+      displayName: 'Print wiki.txt'
+
+    - script: |
+        echo
+        echo "summary.html:"
+        echo
+        cat game-addons/summary.html
+        echo
+      displayName: 'Print summary.html'

--- a/kodi_game_scripting/process_game_addons.py
+++ b/kodi_game_scripting/process_game_addons.py
@@ -471,7 +471,7 @@ class KodiGameAddon():
         """ Pushing changes to GitHub repository """
         print("  Pushing changes to GitHub repository {}".format(self.name))
         branch = self.info['game']['branch']
-        self._repo.push(branch, tags=(branch == 'master'), sleep=(3 * 60))
+        self._repo.push(branch, tags=(branch == 'master'), sleep=1)
 
     def _get_addon_summary(self) -> str:
         """ Helper method to generate an add-on summary from its name and version """


### PR DESCRIPTION
## Description

This PR adds an azure pipeline YML to run the `process_game_addons.py` script.

Template parameters are used to build each game add-on in a separate step. This lets CI logs display how much time individual add-ons took to build.

Currently, the script triggers on master. This should be changed to a cron job, possibly daily compiles and weekly pushes.

@AlwinEsch can we host it on a kodi azure account?

## How has this been tested?

The total build time is unknown, but probably several hours. When testing with my personal Azure account, I have to disable 1/3 of the cores to stay under the 1hr limit. Most cores are quick, with some  outliers:

* FBNeo: 6 mins
* MAME 2010: 12 mins
* MAME 2015: 25 mins
* MAME 2016: 43 mins
* MAME: times out after 1hr
* ScummVM: 22 mins

I enabled every core and triggered a run that will time out after 1hr: https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=119&view=results