### PR TITLE
Add 33 new cores from libretro org

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -78,6 +78,7 @@ ADDONS = {
     'mame':                      ('mame',                       'Makefile.libretro', '.',                 'jni', {'cmake_options': 'PTR64=1'}),  # Huge and longrunning
     'mame2000':                  ('mame2000-libretro',          'Makefile',          '.',                 'jni', {}),
     'mame2003':                  ('mame2003-libretro',          'Makefile',          '.',                 'jni', {}),
+    'mame2003_midway':           ('mame2003_midway',            'Makefile',          '.',                 'jni', {}),
     'mame2003_plus':             ('mame2003-plus-libretro',     'Makefile',          '.',                 'jni', {}),
     'mame2010':                  ('mame2010-libretro',          'Makefile',          '.',                 'jni', {'cmake_options': 'VRENDER=soft PTR64=1'}),  # Huge and longrunning
     'mame2015':                  ('mame2015-libretro',          'Makefile',          '.',                 'jni', {'cmake_options': 'PTR64=1 TARGET=mame'}),  # Huge and longrunning

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -105,6 +105,7 @@ ADDONS = {
     'prboom':                    ('libretro-prboom',            'Makefile',          '.',                 'jni', {}),
     'prosystem':                 ('prosystem-libretro',         'Makefile',          '.',                 'jni', {}),
     'quicknes':                  ('QuickNES_Core',              'Makefile',          '.',                 'jni', {}),
+    'race':                      ('RACE',                       'Makefile',          '.',                 'jni', {}),
     'reminiscence':              ('REminiscence',               'Makefile',          '.',                 'jni', {}),
     'remotejoy':                 ('libretro-remotejoy',         'Makefile',          '.',                 'jni', {}),
     #'rustation':                 ('rustation-libretro',         'Makefile',          '.',                 'jni', {}),  # Checkout fails

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -41,6 +41,7 @@ ADDONS = {
     'beetle-supergrafx':         ('beetle-supergrafx-libretro', 'Makefile',          '.',                 'jni', {'soname': 'mednafen_supergrafx'}),
     'beetle-vb':                 ('beetle-vb-libretro',         'Makefile',          '.',                 'jni', {'soname': 'mednafen_vb'}),
     'beetle-wswan':              ('beetle-wswan-libretro',      'Makefile',          '.',                 'jni', {'soname': 'mednafen_wswan'}),
+    'bk':                        ('bk-emulator',                'Makefile.libretro', '.',                 'jni', {}),
     'blastem':                   ('blastem',                    'Makefile',          '.',                 'android/jni', {}),
     'bluemsx':                   ('blueMSX-libretro',           'Makefile',          '.',                 'jni', {}),
     'bnes':                      ('bnes-libretro',              'Makefile',          '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -53,7 +53,7 @@ ADDONS = {
     'chailove':                  ('libretro-chailove',          'Makefile',          '.',                 'jni', {'git_tag': True}),
     'crocods':                   ('libretro-crocods',           'Makefile',          '.',                 'jni', {}),
     'daphne':                    ('daphne',                     'Makefile',          '.',                 'jni', {}),
-    'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni', {}),  # Fails to build
+    'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni', {}),
     'dinothawr':                 ('Dinothawr',                  'Makefile',          '.',                 'jni', {}),
     #'dolphin':                   ('dolphin',                    '',                  '',                  '', {'cmake': True }),  # Uses git submodules
     'dosbox':                    ('dosbox-libretro',            'Makefile.libretro', '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -78,6 +78,7 @@ ADDONS = {
     'gw':                        ('gw-libretro',                'Makefile',          '.',                 'jni', {}),
     'handy':                     ('libretro-handy',             'Makefile',          '.',                 'jni', {}),
     'hatari':                    ('hatari',                     'Makefile.libretro', '.',                 'jni', {}),
+    'hbmame':                    ('hbmame-libretro',            'Makefile.libretro', '.',                 'jni', {}),
     'lutro':                     ('libretro-lutro',             'Makefile',          '.',                 'jni', {}),
     'mame':                      ('mame',                       'Makefile.libretro', '.',                 'jni', {'cmake_options': 'PTR64=1'}),  # Huge and longrunning
     'mame2000':                  ('mame2000-libretro',          'Makefile',          '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -67,6 +67,7 @@ ADDONS = {
     'flycast':                   ('flycast',                    'Makefile',          '.',                 'jni', {}),
     'fmsx':                      ('fmsx-libretro',              'Makefile',          '.',                 'jni', {}),
     'freechaf':                  ('FreeChaF',                   'Makefile',          '.',                 'jni', {}),
+    'freeintv':                  ('FreeIntv',                   'Makefile',          '.',                 'jni', {}),
     'frodo':                     ('frodo-libretro',             'Makefile',          '.',                 'jni', {}),
     #'fsuae':                     ('libretro-fsuae',             'Makefile.libretro', '.',                 'jni', {'branch': 'libretro-fsuae'}),  # Fails to build
     'fuse':                      ('fuse-libretro',              'Makefile',          '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -105,6 +105,7 @@ ADDONS = {
     'prboom':                    ('libretro-prboom',            'Makefile',          '.',                 'jni', {}),
     'prosystem':                 ('prosystem-libretro',         'Makefile',          '.',                 'jni', {}),
     'quicknes':                  ('QuickNES_Core',              'Makefile',          '.',                 'jni', {}),
+    'reminiscence':              ('REminiscence',               'Makefile',          '.',                 'jni', {}),
     'remotejoy':                 ('libretro-remotejoy',         'Makefile',          '.',                 'jni', {}),
     #'rustation':                 ('rustation-libretro',         'Makefile',          '.',                 'jni', {}),  # Checkout fails
     'sameboy':                   ('SameBoy',                    'Makefile',          'libretro',          'libretro/jni', {'branch': 'buildbot'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -48,6 +48,7 @@ ADDONS = {
     'bsnes-mercury-accuracy':    ('bsnes-mercury',              'Makefile',          '.',                 'target-libretro/jni', {'binary_dir': 'out', 'soname': 'bsnes_mercury_accuracy', 'jnisoname': 'libretro_bsnes_mercury_accuracy', 'cmake_options': 'profile=accuracy'}),
     'bsnes-mercury-balanced':    ('bsnes-mercury',              'Makefile',          '.',                 'target-libretro/jni', {'binary_dir': 'out', 'soname': 'bsnes_mercury_balanced', 'jnisoname': 'libretro_bsnes_mercury_balanced', 'cmake_options': 'profile=balanced'}),
     'bsnes-mercury-performance': ('bsnes-mercury',              'Makefile',          '.',                 'target-libretro/jni', {'binary_dir': 'out', 'soname': 'bsnes_mercury_performance', 'jnisoname': 'libretro_bsnes_mercury_performance', 'cmake_options': 'profile=performance'}),
+    'cannonball':                ('cannonball',                 'Makefile',          '.'  ,               'jni', {}),
     'cap32':                     ('libretro-cap32',             'Makefile',          '.'  ,               'jni', {}),
     'chailove':                  ('libretro-chailove',          'Makefile',          '.',                 'jni', {'git_tag': True}),
     'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni', {}),  # Fails to build

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -27,6 +27,7 @@ GITHUB_ADDON_PREFIX = 'game.libretro.'
 # core: {(Libretro repo, Makefile, Directory)}
 ADDONS = {
     '2048':                      ('libretro-2048',              'Makefile.libretro', '.',                 'jni', {}),
+    '3dengine':                  ('libretro-3dengine',          'Makefile',          '.',                 'jni', {}),
     '81':                        ('81-libretro',                'Makefile',          '.',                 'build/jni', {}),
     'beetle-bsnes':              ('beetle-bsnes-libretro',      'Makefile',          '.',                 'jni', {'soname': 'mednafen_snes'}),
     'beetle-gba':                ('beetle-gba-libretro',        'Makefile',          '.',                 'jni', {'soname': 'mednafen_gba'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -54,6 +54,7 @@ ADDONS = {
     'crocods':                   ('libretro-crocods',           'Makefile',          '.',                 'jni', {}),
     'daphne':                    ('daphne',                     'Makefile',          '.',                 'jni', {}),
     'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni', {}),
+    'desmume2015':               ('desmume2015',                'Makefile.libretro', 'desmume', 'desmume/src/libretro/jni', {}),
     'dinothawr':                 ('Dinothawr',                  'Makefile',          '.',                 'jni', {}),
     #'dolphin':                   ('dolphin',                    '',                  '',                  '', {'cmake': True }),  # Uses git submodules
     'dosbox':                    ('dosbox-libretro',            'Makefile.libretro', '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -133,5 +133,6 @@ ADDONS = {
     'vecx':                      ('libretro-vecx',              'Makefile',          '.',                 'jni', {}),
     #'vice':                      ('vice-libretro',              'Makefile.libretro', '.',                 'jni', {'soname': 'vice_x64'}),  # Settings broken for option API version 0
     'virtualjaguar':             ('virtualjaguar-libretro',     'Makefile',          '.',                 'jni', {}),
+    'xmil':                      ('xmil-libretro',              'Makefile.libretro', 'libretro',          'libretro/jni', {'soname': 'x1'}),
     'yabause':                   ('yabause',                    'Makefile',          'yabause/src/libretro',          'libretro/jni', {}),
 }

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -58,6 +58,7 @@ ADDONS = {
     'dinothawr':                 ('Dinothawr',                  'Makefile',          '.',                 'jni', {}),
     #'dolphin':                   ('dolphin',                    '',                  '',                  '', {'cmake': True }),  # Uses git submodules
     'dosbox':                    ('dosbox-libretro',            'Makefile.libretro', '.',                 'jni', {}),
+    'ecwolf':                    ('ecwolf',                     'Makefile',          'src/libretro',       'src/libretro/jni', {}),
     'fbalpha2012':               ('fbalpha2012',                'makefile.libretro', 'svn-current/trunk', 'svn-current/trunk/projectfiles/libretro-android/jni', {}),
     'fbneo':                     ('FBNeo',                      'Makefile',          'src/burner/libretro', 'jni', {}),
     'fceumm':                    ('libretro-fceumm',            'Makefile',          '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -52,6 +52,7 @@ ADDONS = {
     'cap32':                     ('libretro-cap32',             'Makefile',          '.'  ,               'jni', {}),
     'chailove':                  ('libretro-chailove',          'Makefile',          '.',                 'jni', {'git_tag': True}),
     'crocods':                   ('libretro-crocods',           'Makefile',          '.',                 'jni', {}),
+    'daphne':                    ('daphne',                     'Makefile',          '.',                 'jni', {}),
     'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni', {}),  # Fails to build
     'dinothawr':                 ('Dinothawr',                  'Makefile',          '.',                 'jni', {}),
     #'dolphin':                   ('dolphin',                    '',                  '',                  '', {'cmake': True }),  # Uses git submodules

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -29,6 +29,7 @@ ADDONS = {
     '2048':                      ('libretro-2048',              'Makefile.libretro', '.',                 'jni', {}),
     '3dengine':                  ('libretro-3dengine',          'Makefile',          '.',                 'jni', {}),
     '81':                        ('81-libretro',                'Makefile',          '.',                 'build/jni', {}),
+    'atari800':                  ('libretro-atari800',          'Makefile',          '.',                 'jni', {}),
     'beetle-bsnes':              ('beetle-bsnes-libretro',      'Makefile',          '.',                 'jni', {'soname': 'mednafen_snes'}),
     'beetle-gba':                ('beetle-gba-libretro',        'Makefile',          '.',                 'jni', {'soname': 'mednafen_gba'}),
     'beetle-lynx':               ('beetle-lynx-libretro',       'Makefile',          '.',                 'jni', {'soname': 'mednafen_lynx'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -94,6 +94,7 @@ ADDONS = {
     'meteor':                    ('meteor-libretro',            'Makefile',          'libretro',          'libretro/jni', {}),
     'mgba':                      ('mgba',                       'Makefile',          '.',                 'jni', {}),
     'mrboom':                    ('mrboom-libretro',            'Makefile',          '.',                 'jni', {}),
+    'mu':                        ('Mu',                         'Makefile.libretro', 'libretroBuildSystem', 'libretroBuildSystem/jni', {}),
     'mupen64plus-nx':            ('mupen64plus-libretro-nx',    'Makefile',          '.',                 'jni', {'soname': 'mupen64plus_next'}),
     'nestopia':                  ('nestopia',                   'Makefile',          'libretro',          'libretro/jni', {}),
     'nx':                        ('nxengine-libretro',          'Makefile',          '.',                 'jni', {'soname': 'nxengine'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -117,6 +117,7 @@ ADDONS = {
     #'rustation':                 ('rustation-libretro',         'Makefile',          '.',                 'jni', {}),  # Checkout fails
     'sameboy':                   ('SameBoy',                    'Makefile',          'libretro',          'libretro/jni', {'branch': 'buildbot'}),
     'scummvm':                   ('scummvm',                    'Makefile',          'backends/platform/libretro/build', None, {'binary_dir': 'backends/platform/libretro/build'}),
+    'smsplus-gx':                ('smsplus-gx',                 'Makefile.libretro', '.',                 'jni', {'soname': 'smsplus'}),
     'snes9x':                    ('snes9x',                     'Makefile',          'libretro',          'libretro/jni', {}),
     'snes9x2002':                ('snes9x2002',                 'Makefile',          '.',                 'jni', {}),
     'snes9x2010':                ('snes9x2010',                 'Makefile',          '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -84,6 +84,7 @@ ADDONS = {
     'mame2015':                  ('mame2015-libretro',          'Makefile',          '.',                 'jni', {'cmake_options': 'PTR64=1 TARGET=mame'}),  # Huge and longrunning
     'mame2016':                  ('mame2016-libretro',          'Makefile.libretro', '.',                 'jni', {'cmake_options': 'PTR64=1'}),  # Huge and longrunning
     'melonds':                   ('melonDS',                    'Makefile',          '.',                 'jni', {}),
+    'meowpc98':                  ('libretro-meowPC98',          'Makefile.libretro', 'libretro',          'libretro/jni', {'soname': 'nekop2'}),
     'mesen':                     ('SourMesen/Mesen',            'Makefile',          'Libretro',          'libretro/jni', {}),
     'meteor':                    ('meteor-libretro',            'Makefile',          'libretro',          'libretro/jni', {}),
     'mgba':                      ('mgba',                       'Makefile',          '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -105,6 +105,7 @@ ADDONS = {
     'prboom':                    ('libretro-prboom',            'Makefile',          '.',                 'jni', {}),
     'prosystem':                 ('prosystem-libretro',         'Makefile',          '.',                 'jni', {}),
     'quicknes':                  ('QuickNES_Core',              'Makefile',          '.',                 'jni', {}),
+    'remotejoy':                 ('libretro-remotejoy',         'Makefile',          '.',                 'jni', {}),
     #'rustation':                 ('rustation-libretro',         'Makefile',          '.',                 'jni', {}),  # Checkout fails
     'sameboy':                   ('SameBoy',                    'Makefile',          'libretro',          'libretro/jni', {'branch': 'buildbot'}),
     'scummvm':                   ('scummvm',                    'Makefile',          'backends/platform/libretro/build', None, {'binary_dir': 'backends/platform/libretro/build'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -94,6 +94,7 @@ ADDONS = {
     'nx':                        ('nxengine-libretro',          'Makefile',          '.',                 'jni', {'soname': 'nxengine'}),
     'o2em':                      ('libretro-o2em',              'Makefile',          '.',                 'jni', {}),
     'opera':                     ('opera-libretro',             'Makefile',          '.',                 'jni', {}),
+    'openlara':                  ('OpenLara',                   'Makefile',          'src/platform/libretro', 'src/platform/libretro/jni', {}),
     'parallel_n64':              ('parallel-n64',               'Makefile',          '.',                 'jni', {}),
     'pcem':                      ('libretro-pcem',              'Makefile.libretro', 'src',               'jni', {}),
     'pcsx-rearmed':              ('pcsx_rearmed',               'Makefile.libretro', '.',                 'jni', {'soname': 'pcsx_rearmed'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -107,6 +107,7 @@ ADDONS = {
     'ppsspp':                    ('ppsspp',                     'Makefile',          'libretro',          'jni', {}),  # Longrunning, requires OpenGL
     'prboom':                    ('libretro-prboom',            'Makefile',          '.',                 'jni', {}),
     'prosystem':                 ('prosystem-libretro',         'Makefile',          '.',                 'jni', {}),
+    'px68k':                     ('px68k-libretro',             'Makefile.libretro', '.',                 'jni', {}),
     'quasi88':                   ('quasi88-libretro',           'Makefile',          '.',                 'jni', {}),
     'quicknes':                  ('QuickNES_Core',              'Makefile',          '.',                 'jni', {}),
     'race':                      ('RACE',                       'Makefile',          '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -62,13 +62,13 @@ ADDONS = {
     'handy':                     ('libretro-handy',             'Makefile',          '.',                 'jni', {}),
     'hatari':                    ('hatari',                     'Makefile.libretro', '.',                 'jni', {}),
     'lutro':                     ('libretro-lutro',             'Makefile',          '.',                 'jni', {}),
-    #'mame':                      ('mame',                       'Makefile.libretro', '.',                 'jni', {'cmake_options': 'PTR64=1'}),  # Huge and longrunning
+    'mame':                      ('mame',                       'Makefile.libretro', '.',                 'jni', {'cmake_options': 'PTR64=1'}),  # Huge and longrunning
     'mame2000':                  ('mame2000-libretro',          'Makefile',          '.',                 'jni', {}),
     'mame2003':                  ('mame2003-libretro',          'Makefile',          '.',                 'jni', {}),
     'mame2003_plus':             ('mame2003-plus-libretro',     'Makefile',          '.',                 'jni', {}),
     'mame2010':                  ('mame2010-libretro',          'Makefile',          '.',                 'jni', {'cmake_options': 'VRENDER=soft PTR64=1'}),  # Huge and longrunning
     'mame2015':                  ('mame2015-libretro',          'Makefile',          '.',                 'jni', {'cmake_options': 'PTR64=1 TARGET=mame'}),  # Huge and longrunning
-    #'mame2016':                  ('mame2016-libretro',          'Makefile.libretro', '.',                 'jni', {'cmake_options': 'PTR64=1'}),  # Huge and longrunning
+    'mame2016':                  ('mame2016-libretro',          'Makefile.libretro', '.',                 'jni', {'cmake_options': 'PTR64=1'}),  # Huge and longrunning
     'melonds':                   ('melonDS',                    'Makefile',          '.',                 'jni', {}),
     'mesen':                     ('SourMesen/Mesen',            'Makefile',          'Libretro',          'libretro/jni', {}),
     'meteor':                    ('meteor-libretro',            'Makefile',          'libretro',          'libretro/jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -51,6 +51,7 @@ ADDONS = {
     'cannonball':                ('cannonball',                 'Makefile',          '.'  ,               'jni', {}),
     'cap32':                     ('libretro-cap32',             'Makefile',          '.'  ,               'jni', {}),
     'chailove':                  ('libretro-chailove',          'Makefile',          '.',                 'jni', {'git_tag': True}),
+    'craft':                     ('Craft',                      'Makefile.libretro', '.',                 'jni', {}),
     'crocods':                   ('libretro-crocods',           'Makefile',          '.',                 'jni', {}),
     'daphne':                    ('daphne',                     'Makefile',          '.',                 'jni', {}),
     'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -41,6 +41,7 @@ ADDONS = {
     'beetle-supergrafx':         ('beetle-supergrafx-libretro', 'Makefile',          '.',                 'jni', {'soname': 'mednafen_supergrafx'}),
     'beetle-vb':                 ('beetle-vb-libretro',         'Makefile',          '.',                 'jni', {'soname': 'mednafen_vb'}),
     'beetle-wswan':              ('beetle-wswan-libretro',      'Makefile',          '.',                 'jni', {'soname': 'mednafen_wswan'}),
+    'blastem':                   ('blastem',                    'Makefile',          '.',                 'android/jni', {}),
     'bluemsx':                   ('blueMSX-libretro',           'Makefile',          '.',                 'jni', {}),
     'bnes':                      ('bnes-libretro',              'Makefile',          '.',                 'jni', {}),
     'bsnes-mercury-accuracy':    ('bsnes-mercury',              'Makefile',          '.',                 'target-libretro/jni', {'binary_dir': 'out', 'soname': 'bsnes_mercury_accuracy', 'jnisoname': 'libretro_bsnes_mercury_accuracy', 'cmake_options': 'profile=accuracy'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -65,6 +65,7 @@ ADDONS = {
     'flycast':                   ('flycast',                    'Makefile',          '.',                 'jni', {}),
     'fmsx':                      ('fmsx-libretro',              'Makefile',          '.',                 'jni', {}),
     'freechaf':                  ('FreeChaF',                   'Makefile',          '.',                 'jni', {}),
+    'frodo':                     ('frodo-libretro',             'Makefile',          '.',                 'jni', {}),
     #'fsuae':                     ('libretro-fsuae',             'Makefile.libretro', '.',                 'jni', {'branch': 'libretro-fsuae'}),  # Fails to build
     'fuse':                      ('fuse-libretro',              'Makefile',          '.',                 'jni', {}),
     'gambatte':                  ('gambatte-libretro',          'Makefile',          '.',                 'libgambatte/libretro/jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -64,6 +64,7 @@ ADDONS = {
     'fceumm':                    ('libretro-fceumm',            'Makefile',          '.',                 'jni', {}),
     'flycast':                   ('flycast',                    'Makefile',          '.',                 'jni', {}),
     'fmsx':                      ('fmsx-libretro',              'Makefile',          '.',                 'jni', {}),
+    'freechaf':                  ('FreeChaF',                   'Makefile',          '.',                 'jni', {}),
     #'fsuae':                     ('libretro-fsuae',             'Makefile.libretro', '.',                 'jni', {'branch': 'libretro-fsuae'}),  # Fails to build
     'fuse':                      ('fuse-libretro',              'Makefile',          '.',                 'jni', {}),
     'gambatte':                  ('gambatte-libretro',          'Makefile',          '.',                 'libgambatte/libretro/jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -27,6 +27,7 @@ GITHUB_ADDON_PREFIX = 'game.libretro.'
 # core: {(Libretro repo, Makefile, Directory)}
 ADDONS = {
     '2048':                      ('libretro-2048',              'Makefile.libretro', '.',                 'jni', {}),
+    '81':                        ('81-libretro',                'Makefile',          '.',                 'build/jni', {}),
     'beetle-bsnes':              ('beetle-bsnes-libretro',      'Makefile',          '.',                 'jni', {'soname': 'mednafen_snes'}),
     'beetle-gba':                ('beetle-gba-libretro',        'Makefile',          '.',                 'jni', {'soname': 'mednafen_gba'}),
     'beetle-lynx':               ('beetle-lynx-libretro',       'Makefile',          '.',                 'jni', {'soname': 'mednafen_lynx'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -101,6 +101,7 @@ ADDONS = {
     'opera':                     ('opera-libretro',             'Makefile',          '.',                 'jni', {}),
     'openlara':                  ('OpenLara',                   'Makefile',          'src/platform/libretro', 'src/platform/libretro/jni', {}),
     'parallel_n64':              ('parallel-n64',               'Makefile',          '.',                 'jni', {}),
+    'parallext':                 ('parallext',                  'Makefile',          '.',                 'libretro/jni', {'soname': 'parallel_n64'}),
     'pcem':                      ('libretro-pcem',              'Makefile.libretro', 'src',               'jni', {}),
     'pcsx-rearmed':              ('pcsx_rearmed',               'Makefile.libretro', '.',                 'jni', {'soname': 'pcsx_rearmed'}),
     'picodrive':                 ('picodrive',                  'Makefile.libretro', '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -51,6 +51,7 @@ ADDONS = {
     'cannonball':                ('cannonball',                 'Makefile',          '.'  ,               'jni', {}),
     'cap32':                     ('libretro-cap32',             'Makefile',          '.'  ,               'jni', {}),
     'chailove':                  ('libretro-chailove',          'Makefile',          '.',                 'jni', {'git_tag': True}),
+    'crocods':                   ('libretro-crocods',           'Makefile',          '.',                 'jni', {}),
     'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni', {}),  # Fails to build
     'dinothawr':                 ('Dinothawr',                  'Makefile',          '.',                 'jni', {}),
     #'dolphin':                   ('dolphin',                    '',                  '',                  '', {'cmake': True }),  # Uses git submodules

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -118,6 +118,7 @@ ADDONS = {
     'snes9x2002':                ('snes9x2002',                 'Makefile',          '.',                 'jni', {}),
     'snes9x2010':                ('snes9x2010',                 'Makefile',          '.',                 'jni', {}),
     'stella':                    ('stella-libretro',            'Makefile',          '.',                 'jni', {'soname': 'stella2014'}),
+    'supafaust':                 ('supafaust',                  'Makefile',          '.',                 'jni', {'soname': 'mednafen_supafaust'}),
     'tgbdual':                   ('tgbdual-libretro',           'Makefile',          '.',                 'jni', {}),
     'theodore':                  ('Zlika/theodore',             'Makefile',          '.',                  'jni', {}),
     'thepowdertoy':              ('ThePowderToy',               '',                  '',                  '', {'cmake': True, 'binary_dir': 'src'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -44,6 +44,7 @@ ADDONS = {
     'blastem':                   ('blastem',                    'Makefile',          '.',                 'android/jni', {}),
     'bluemsx':                   ('blueMSX-libretro',           'Makefile',          '.',                 'jni', {}),
     'bnes':                      ('bnes-libretro',              'Makefile',          '.',                 'jni', {}),
+    'boom3':                     ('boom3',                      'Makefile',          'neo',               'jni', {}),
     'bsnes-mercury-accuracy':    ('bsnes-mercury',              'Makefile',          '.',                 'target-libretro/jni', {'binary_dir': 'out', 'soname': 'bsnes_mercury_accuracy', 'jnisoname': 'libretro_bsnes_mercury_accuracy', 'cmake_options': 'profile=accuracy'}),
     'bsnes-mercury-balanced':    ('bsnes-mercury',              'Makefile',          '.',                 'target-libretro/jni', {'binary_dir': 'out', 'soname': 'bsnes_mercury_balanced', 'jnisoname': 'libretro_bsnes_mercury_balanced', 'cmake_options': 'profile=balanced'}),
     'bsnes-mercury-performance': ('bsnes-mercury',              'Makefile',          '.',                 'target-libretro/jni', {'binary_dir': 'out', 'soname': 'bsnes_mercury_performance', 'jnisoname': 'libretro_bsnes_mercury_performance', 'cmake_options': 'profile=performance'}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -132,6 +132,7 @@ ADDONS = {
     'tyrquake':                  ('tyrquake',                   'Makefile',          '.',                 'jni', {}),
     'uae':                       ('libretro-uae',               'Makefile',          '.',                 'jni', {'soname': 'puae'}),
     #'uae4arm':                   ('uae4arm-libretro',           'Makefile',          '.',                 'jni', {}),  # Fails to build on non arm system
+    'uzem':                      ('libretro-uzem',              'Makefile.libretro', '.',                 'jni', {}),
     'vba-next':                  ('vba-next',                   'Makefile',          '.',                 'libretro/jni', {'soname': 'vba_next'}),
     'vbam':                      ('vbam-libretro',              'Makefile',          'src/libretro',      'src/libretro/jni', {}),
     'vecx':                      ('libretro-vecx',              'Makefile',          '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -59,6 +59,7 @@ ADDONS = {
     'dinothawr':                 ('Dinothawr',                  'Makefile',          '.',                 'jni', {}),
     #'dolphin':                   ('dolphin',                    '',                  '',                  '', {'cmake': True }),  # Uses git submodules
     'dosbox':                    ('dosbox-libretro',            'Makefile.libretro', '.',                 'jni', {}),
+    'dosbox-core':               ('dosbox-core',                'Makefile.libretro', 'libretro',          'libretro/jni', {'branch': 'libretro --'}),  # Requires CMake 3.11 or higher
     'ecwolf':                    ('ecwolf',                     'Makefile',          'src/libretro',       'src/libretro/jni', {}),
     'fbalpha2012':               ('fbalpha2012',                'makefile.libretro', 'svn-current/trunk', 'svn-current/trunk/projectfiles/libretro-android/jni', {}),
     'fbneo':                     ('FBNeo',                      'Makefile',          'src/burner/libretro', 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -99,6 +99,7 @@ ADDONS = {
     'pcem':                      ('libretro-pcem',              'Makefile.libretro', 'src',               'jni', {}),
     'pcsx-rearmed':              ('pcsx_rearmed',               'Makefile.libretro', '.',                 'jni', {'soname': 'pcsx_rearmed'}),
     'picodrive':                 ('picodrive',                  'Makefile.libretro', '.',                 'jni', {}),
+    'pocketcdg':                 ('libretro-pocketcdg',         'Makefile',          '.',                 'jni', {}),
     'pokemini':                  ('PokeMini',                   'Makefile.libretro', '.',                 'jni', {}),
     'ppsspp':                    ('ppsspp',                     'Makefile',          'libretro',          'jni', {}),  # Longrunning, requires OpenGL
     'prboom':                    ('libretro-prboom',            'Makefile',          '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -70,6 +70,7 @@ ADDONS = {
     'fuse':                      ('fuse-libretro',              'Makefile',          '.',                 'jni', {}),
     'gambatte':                  ('gambatte-libretro',          'Makefile',          '.',                 'libgambatte/libretro/jni', {}),
     'genplus':                   ('Genesis-Plus-GX',            'Makefile.libretro', '.',                 'libretro/jni', {'soname': 'genesis_plus_gx'}),
+    'gpsp':                      ('gpsp',                       'Makefile',          '.',                 'jni', {}),
     'gw':                        ('gw-libretro',                'Makefile',          '.',                 'jni', {}),
     'handy':                     ('libretro-handy',             'Makefile',          '.',                 'jni', {}),
     'hatari':                    ('hatari',                     'Makefile.libretro', '.',                 'jni', {}),

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -107,6 +107,7 @@ ADDONS = {
     'ppsspp':                    ('ppsspp',                     'Makefile',          'libretro',          'jni', {}),  # Longrunning, requires OpenGL
     'prboom':                    ('libretro-prboom',            'Makefile',          '.',                 'jni', {}),
     'prosystem':                 ('prosystem-libretro',         'Makefile',          '.',                 'jni', {}),
+    'quasi88':                   ('quasi88-libretro',           'Makefile',          '.',                 'jni', {}),
     'quicknes':                  ('QuickNES_Core',              'Makefile',          '.',                 'jni', {}),
     'race':                      ('RACE',                       'Makefile',          '.',                 'jni', {}),
     'reminiscence':              ('REminiscence',               'Makefile',          '.',                 'jni', {}),


### PR DESCRIPTION
## Description

I added config lines for most of the remaining cores at https://github.com/libretro.

Game add-ons on the kodi-game org have been created and are up-to-date. I added summaries on all the repo pages. I set the URLs of all newly created repo pages to the upstream libretro repos.

Adds the following cores:

- 3D Engine
- 81/EightyOne (Sinclair - ZX 81)
- Atari800 (Atari - 5200)
- BK (Soviet BK-0010/0011/Terak 8510a emulator)
- BlastEm (Sega - Mega Drive - Genesis)
- boom3 (Doom 3)
- Cannonball
- Craft (Minecraft clone)
- CrocoDS (Amstrad - CPC)
- Daphne (Arcade)
- Desmume 2015 (Nintendo DS emulator)
- dosbox-core
- ECWolf (Wolfenstein 3D engine)
- FreeChaF (Fairchild ChannelF emulator)
- FreeIntv (Mattel Intellivision emulator)
- Frodo (C64 emulator)
- gameplaySP (GBA emulator)
- HBMAME (Home Brew MAME)
- MAME 2003 Midway
- Mu (Palm OS emulator)
- Neko Project 2 (PC-98 emulator)
- OpenLara
- paraLLeXT (N64 emualtor)
- PocketCDG
- px68k (Portable SHARP X68000 emulator)
- QUASI88 (PC-8800 emulator)
- RACE (NGPC emulator)
- REminiscence (Flashback emulator)
- RemoteJoy
- SMSPlus-GX (Sega MS/GG emulator)
- Supafaust (experimental SNES emulator)
- Uzem (Uzebox emulator)
- xmil (X Millennium Sharp X1 emulator)

## How has this been tested?

Azure pipeline run of all new cores (except blastem and dosbox-core): https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=195&view=results