### PR TITLE
Fix pylint errors causing CI failures

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -18,7 +18,7 @@
 
     Override settings for specific libretro cores. """
 
-# pylint: disable=bad-whitespace, line-too-long
+# pylint: disable=bad-option-value, bad-whitespace, line-too-long
 # flake8: noqa
 
 GITHUB_ORGANIZATION = 'kodi-game'

--- a/kodi_game_scripting/git_access.py
+++ b/kodi_game_scripting/git_access.py
@@ -61,10 +61,10 @@ class GitHubOrg:
             if auth and not apitoken:
                 cred.save(username, password)
             self._org = self._github.get_organization(org)
-        except github.BadCredentialsException:
+        except github.BadCredentialsException as err:
             if auth and not apitoken:
                 cred.clean()
-            raise ValueError("Authentication to GitHub failed")
+            raise ValueError("Authentication to GitHub failed") from err
 
     @functools.lru_cache()
     def get_repos(self, regex):


### PR DESCRIPTION
## Description

Every PR I've opened but one is red. I'll shove this in and rebase the others so we can be swimming in a beautiful ocean of green check marks.

## How has this been tested?

Before, pylint errors causing CI failure:

```
__________________ [pylint] kodi_game_scripting/git_access.py __________________
W: 67,12: Consider explicitly re-raising using the 'from' keyword (raise-missing-from)
____________________ [pylint] kodi_game_scripting/config.py ____________________
E: 21, 0: Bad option value 'bad-whitespace' (bad-option-value)
```

After, no pylint errors occur and CI succeeds.
