### PR TITLE
Don't sort settings by ID

### DIFF
--- a/kodi_game_scripting/process_game_addons.py
+++ b/kodi_game_scripting/process_game_addons.py
@@ -326,8 +326,7 @@ class KodiGameAddon():
             library = LibretroWrapper(library_path)
             self.info['library']['loaded'] = True
             self.info['system_info'] = library.system_info
-            self.info['settings'] = sorted(library.variables,
-                                           key=lambda x: x.id)
+            self.info['settings'] = library.variables
             self.info['library']['opengl'] = library.opengl_linkage
         except OSError as err:
             self.info['library']['error'] = err


### PR DESCRIPTION
## Description

As title says.

According to @KOPRajs [here](https://github.com/kodi-game/game.libretro.pcsx-rearmed/issues/19#issuecomment-844994685):

```
Regarding the order of the settings:
It seems we are currently reordering the original options order from libretro to alphabet order. I don't think it is a good idea. The order in the libretro makes sense as related options are kept together.

It seems it is done on line 329 in this file: https://github.com/kodi-game/kodi-game-scripting/blob/master/kodi_game_scripting/process_game_addons.py

I'd suggest to simply remove the "sorted" function and keep the libretro default order.
```

I tried removing `sorted`, and it looks like settings are now in their original order.

## Related PRs

Required by https://github.com/kodi-game/kodi-game-scripting/pull/86

## How has this been tested?

Tested as part of https://github.com/kodi-game/game.libretro.pcsx-rearmed/pull/21