### PR TITLE
Use curl for mingw package downloads

### DIFF
--- a/templates/addon/depends/windows/mingw/03-use-curl.patch.j2
+++ b/templates/addon/depends/windows/mingw/03-use-curl.patch.j2
@@ -1,0 +1,13 @@
+{% if not makefile.cmake %}
+--- a/etc/pacman.conf	Fri Jul 15 02:58:59 2016
++++ b/etc/pacman.conf	Tue Oct 20 20:36:28 2020
+@@ -15,7 +15,7 @@
+ #LogFile     = /var/log/pacman.log
+ #GPGDir      = /etc/pacman.d/gnupg/
+ HoldPkg      = pacman
+-#XferCommand = /usr/bin/curl -C - -f %u > %o
++XferCommand = /usr/bin/curl -k --retry 5 -L -C - -f %u > %o
+ #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
+ #CleanMethod = KeepInstalled
+ #UseDelta    = 0.7
+{% endif %}


### PR DESCRIPTION
## Description

I noticed that almost all windows builds were failing to download msys during CI runs. @phunkyfish pointed me to his solution: https://github.com/xbmc/inputstream.ffmpegdirect/commit/13ccd30485f8781e437e8f09d5e31e62a04f8661, part of https://github.com/xbmc/inputstream.ffmpegdirect/pull/83.

So let's apply that here.

## How has this been tested?

Before: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.yabause/detail/master/64/pipeline/

After: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.yabause/detail/master/65/pipeline/

I've observed about 10 more successful runs since then with no failures, so I'll push this out to the fleet of add-ons.