### PR TITLE
Enable dolphin in config.py

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -58,7 +58,7 @@ ADDONS = {
     'desmume':                   ('desmume',                    'Makefile.libretro', 'desmume/src/frontend/libretro', 'desmume/src/frontend/libretro/jni', {}),
     'desmume2015':               ('desmume2015',                'Makefile.libretro', 'desmume', 'desmume/src/libretro/jni', {}),
     'dinothawr':                 ('Dinothawr',                  'Makefile',          '.',                 'jni', {}),
-    #'dolphin':                   ('dolphin',                    '',                  '',                  '', {'cmake': True }),  # Uses git submodules
+    'dolphin':                   ('dolphin',                    '',                  '',                  '', {'cmake': True }),
     'dosbox':                    ('dosbox-libretro',            'Makefile.libretro', '.',                 'jni', {}),
     'dosbox-core':               ('dosbox-core',                'Makefile.libretro', 'libretro',          'libretro/jni', {'branch': 'libretro --', 'cmake_options': 'BUNDLED_SDL=1', 'soname': 'dosbox_core'}),
     'dosbox-pure':               ('dosbox-pure',                'Makefile',          '.',                 'jni', {'branch': 'main', 'soname': 'dosbox_pure'}),


### PR DESCRIPTION
## Description

After messing with dependencies I got dolphin to build, and pushed the latest to game.libretro.dolphin. Let's enable dolphin in config.py so that the script keeps the repo up-to-date.

## How has this been tested?

Blue Ocean view: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.dolphin/detail/13.0.0.2-Matrix/1/pipeline/