### PR TITLE
Switch to .tar.gz archives for libretro core sources

### DIFF
--- a/templates/addon/depends/common/{{ game.name }}/{{ game.name }}.txt.j2
+++ b/templates/addon/depends/common/{{ game.name }}/{{ game.name }}.txt.j2
@@ -1,5 +1,5 @@
 {% if not libretro_repo.git_tag and libretro_repo.hexsha %}
-{{ game.name }} https://github.com/{{ libretro_repo.org | default('libretro') }}/{{ libretro_repo.name | default(game.name) }}/archive/{{ libretro_repo.hexsha }}.zip
+{{ game.name }} https://github.com/{{ libretro_repo.org | default('libretro') }}/{{ libretro_repo.name | default(game.name) }}/archive/{{ libretro_repo.hexsha }}.tar.gz
 {% else %}
 {{ game.name }} https://github.com/{{ libretro_repo.org | default('libretro') }}/{{ libretro_repo.name | default(game.name) }} {{ libretro_repo.branch }}
 {% endif %}


### PR DESCRIPTION
## Description

On some platforms, pcem fails on Jenkins with the following error:

```
-- extracting...
     src='download/1955c2127990cfdf4c594b35b466e8503d626fa7.zip'
     dst='pcem/src/pcem'
-- extracting... [tar xfz]

CMake Error: Problem with archive_read_next_header(): Pathname cannot be converted from UTF-8 to current locale.
CMake Error: Problem extracting tar: download/1955c2127990cfdf4c594b35b466e8503d626fa7.zip
```

Link to CI run: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.pcem/detail/master/54/pipeline/232

I also noticed this for other cores, but forget which ones.

We should fix the extension for all cores, because zips are a no-go for our dependency stuff.

Unfortunately, we detect the extension change as a hash change and bump the version, so this will cause a heavy CI load the next few hours and bloat files on the mirrors.

## How has this been tested?

 Link where pcem extracts (though fails to compile): https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.pcem/detail/master/55/pipeline
 
 Successful run of yabuase: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.yabause/detail/master/66/pipeline