### PR TITLE
Update templates for Weblate translation

### DIFF
--- a/kodi_game_scripting/template_processor.py
+++ b/kodi_game_scripting/template_processor.py
@@ -19,8 +19,6 @@
 import os
 import re
 import shutil
-import xml.etree.ElementTree
-import xmljson
 
 import jinja2
 
@@ -86,31 +84,7 @@ class TemplateProcessor:
                 # the template. That way templates can decide what data to keep
                 # or override.
                 if '.xml' in infile and os.path.isfile(outfile_path):
-                    with open(outfile_path, 'r') as xmlfile_ctx:
-                        xml_content = xmlfile_ctx.read()
-
-                    # Remove variables from xml.in files
-                    xml_content = re.sub(r'@([A-Za-z0-9_]+)@', r'AT_\1_AT',
-                                         xml_content)
-                    xml_data = {}
-                    try:
-                        # Like Yahoo converter, but don't omit 'content' if
-                        # there are no attributes.
-                        converter = xmljson.XMLData(
-                            xml_fromstring=False,
-                            simple_text=False,
-                            text_content="content"
-                        )
-                        root = xml.etree.ElementTree.fromstring(xml_content)
-                        xml_data = converter.data(root)
-
-                        # Parsed XML Data will contain OrderedDict() as empty
-                        # value which converts to 'OrderedDict()' instead of ''
-                        # in the templates. Remove empty fields instead.
-                        xml_data = utils.purify(xml_data)
-                    except xml.etree.ElementTree.ParseError as err:
-                        print("Failed to parse {}: {}".format(
-                            outfile_path, err))
+                    xml_data = utils.get_xml_data(outfile_path)
                     template_vars.update({'xml': xml_data})
 
                 # Make the datetime of strings files the existing datetime

--- a/templates/addon/{{ game.addon }}/addon.xml.in.j2
+++ b/templates/addon/{{ game.addon }}/addon.xml.in.j2
@@ -21,28 +21,6 @@
 		<supports_standalone>{{ system_info.supports_no_game | default('false') | lower }}</supports_standalone>
 	</extension>
 	<extension point="xbmc.addon.metadata">
-		{% set summary = addon_name %}
-		{% if system_info.version %}
-			{% set summary = summary + ' ' + system_info.version %}
-		{% endif %}
-		<summary lang="en_GB">{{ summary | e }}</summary>
-		{% if system_info.extensions %}
-			{% set extensions = 'Supported files: ' + system_info.extensions | map('regex_replace', '(.+)', '.\\1') | join(', ') %}
-		{% endif %}
-		{% set description = xml.addon.extension[1].description.content | default('') %}
-		{% if ("Supported files: " in xml.addon.extension[1].description.content) %}
-			{% set description = xml.addon.extension[1].description.content | regex_replace('Supported files: (?:\\.\\w+)(?:,\\s*\\.\\w+)*', extensions | default('')) %}
-		{% elif extensions %}
-			{% set description = xml.addon.extension[1].description.content | default('') + '\n\n' + extensions %}
-		{% endif %}
-		{% if ("License: " in xml.addon.extension[1].description.content) %}
-			{% set description = description | regex_replace('License: .*', '') %}
-		{% endif %}
-		{% set description = description | regex_replace('^(\\s*\\n){2,}', '\n', multiline=True) | trim %}
-		<description lang="en_GB">{{ description | e }}</description>
-		{% if xml.addon.extension[1].disclaimer %}
-		<disclaimer>{{ xml.addon.extension[1].disclaimer.content | e }}</disclaimer>
-		{% endif %}
 		<license>{{ libretro_info.license | default(xml.addon.extension[1].license.content) | default('') | e }}</license>
 		<platform>@PLATFORM@</platform>
 		<source>https://github.com/kodi-game/{{ game.addon }}</source>
@@ -59,5 +37,10 @@
 			{% endfor %}
 		</assets>
 		{% endif %}
+		{% if xml.addon.extension[1].disclaimer %}
+		<disclaimer>{{ xml.addon.extension[1].disclaimer.content | e }}</disclaimer>
+		{% endif %}
+		<summary lang="en_GB">{{ game.summary | e }}</summary>
+		<description lang="en_GB">{{ game.description | e }}</description>
 	</extension>
 </addon>

--- a/templates/addon/{{ game.addon }}/resources/language/resource.language.en_gb/strings.po.j2
+++ b/templates/addon/{{ game.addon }}/resources/language/resource.language.en_gb/strings.po.j2
@@ -1,4 +1,3 @@
-{% if settings %}
 # {{ game.addon }} language file
 # Addon Name: {{ game.addon }}
 # Addon id: {{ game.addon }}
@@ -6,17 +5,26 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: {{ game.addon }}\n"
-"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"Report-Msgid-Bugs-To: translations@kodi.tv\n"
 "POT-Creation-Date: {{ datetime }}\n"
 "PO-Revision-Date: {{ datetime }}\n"
 "Last-Translator: Kodi Translation Team\n"
-"Language-Team: English (http://www.transifex.com/projects/p/xbmc-addons/language/en/)\n"
+"Language-Team: English (https://kodi.weblate.cloud/languages/en_gb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+msgctxt "Addon Summary"
+msgid "{{ game.summary | e }}"
+msgstr ""
+
+msgctxt "Addon Description"
+msgid "{{ game.description | e }}"
+msgstr ""
+
+{% if settings %}
 msgctxt "#30000"
 msgid "Settings"
 msgstr ""


### PR DESCRIPTION
## Description

This PR updates the templates to always generate language files from the summary and description. In order to do this, string generation was moved out of the template and into the Python code, allowing for summary/description re-use between addon.xml and strings.po.

## How has this been tested?

Latest CI run: https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=485&view=logs&j=3c6d0c73-cb56-5412-ce34-70e581ba56b9