### PR TITLE
Add `requires_opengl` tag to addon.xml.in

### DIFF
--- a/templates/addon/{{ game.addon }}/addon.xml.in.j2
+++ b/templates/addon/{{ game.addon }}/addon.xml.in.j2
@@ -19,6 +19,7 @@
 		<extensions>{{ system_info.extensions | join('|') | e }}</extensions>
 		<supports_vfs>{{ 'false' if system_info.need_fullpath | default('true') else 'true' }}</supports_vfs>
 		<supports_standalone>{{ system_info.supports_no_game | default('false') | lower }}</supports_standalone>
+		<requires_opengl>{{ 'true' if library.opengl | default('false') else 'false' }}</requires_opengl>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<license>{{ libretro_info.license | default(xml.addon.extension[1].license.content) | default('') | e }}</license>


### PR DESCRIPTION
## Description

This PR exposes the GL requirement to the Game API, as seen in the wiki: https://kodi.wiki/view/Game_add-ons#Libretro_cores

Unused in Kodi as of yet but we may as well expose it now, to inform readers of addon.xml whether the core is GL-compatible, and later we can show a custom message in Kodi's GUI.

## How has this been tested?

Tested with yabause: https://github.com/kodi-game/game.libretro.yabause/commit/c09aba3cc28fed8abf49f1c170f7cac08ce14a51