### PR TITLE
Change Jenkins to upload Matrix builds

### DIFF
--- a/kodi_game_scripting/process_game_addons.py
+++ b/kodi_game_scripting/process_game_addons.py
@@ -463,7 +463,7 @@ class KodiGameAddon():
         """ Creating tags in Git repository """
         print("  Creating tags in Git repository {}: {}".format(
             self.name, self.info['game']['version']))
-        for branch in ['Matrix', 'Nexus']:
+        for branch in ['Matrix']:
             self._repo.tag('{}-{}'.format(self.info['game']['version'], branch))
 
     def push(self):

--- a/templates/addon/Jenkinsfile.j2
+++ b/templates/addon/Jenkinsfile.j2
@@ -1,1 +1,1 @@
-buildPlugin(version: "Nexus", platforms: {{ ['android-aarch64', 'android-armv7', 'osx-x86_64', 'tvos-aarch64', 'ubuntu-ppa', 'windows-i686', 'windows-x86_64']|reject("in", libretro_repo.exclude_platforms)|list()|tojson() }})
+buildPlugin(version: "Matrix", platforms: {{ ['android-aarch64', 'android-armv7', 'osx-x86_64', 'tvos-aarch64', 'ubuntu-ppa', 'windows-i686', 'windows-x86_64']|reject("in", libretro_repo.exclude_platforms)|list()|tojson() }})


### PR DESCRIPTION
## Description

Currently, Jenkins performs builds for Matrix and Nexus, and uploads both to the Nexus repository. This PR change the upload target to the Matrix repo, and changes the tagged repos to only Matrix to avoid uploading to the same location twice.

## How has this been tested?

Link to CI run: https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=631&view=logs&j=3c6d0c73-cb56-5412-ce34-70e581ba56b9