### PR TITLE
Fix escaping XML using numeric references instead of named references

### DIFF
--- a/kodi_game_scripting/template_processor.py
+++ b/kodi_game_scripting/template_processor.py
@@ -43,6 +43,17 @@ def regex_replace(string, find, replace, *, multiline=False):
     return re.sub(find, replace, string, flags=flags)
 
 
+def escape_xml(string):
+    """Filter: Replace unsafe XML characters with named references"""
+    return (
+        string.replace('&', '&amp;')
+        .replace("'", '&apos;')
+        .replace('"', '&quot;')
+        .replace('<', '&lt;')
+        .replace('>', '&gt;')
+    )
+
+
 class TemplateProcessor:
     """ Process Jinja2 templates """
 
@@ -65,6 +76,7 @@ class TemplateProcessor:
 
         template_env.filters["regex_replace"] = regex_replace
         template_env.filters["get_list"] = get_list
+        template_env.filters["escape_xml"] = escape_xml
 
         # Loop over all templates
         for infile in utils.list_all_files(template_dir):

--- a/templates/addon/{{ game.addon }}/addon.xml.in.j2
+++ b/templates/addon/{{ game.addon }}/addon.xml.in.j2
@@ -39,13 +39,13 @@
 		</assets>
 		{% endif %}
 		{% for summary in game.summaries %}
-		<summary lang="{{ summary.lang | default('en_GB') | escape }}">{{ summary.content | escape }}</summary>
+		<summary lang="{{ summary.lang | default('en_GB') | escape }}">{{ summary.content | escape_xml }}</summary>
 		{% endfor %}
 		{% for description in game.descriptions %}
-		<description lang="{{ description.lang | default('en_GB') | escape }}">{{ description.content | escape }}</description>
+		<description lang="{{ description.lang | default('en_GB') | escape }}">{{ description.content | escape_xml }}</description>
 		{% endfor %}
 		{% for disclaimer in game.disclaimers %}
-		<disclaimer lang="{{ disclaimer.lang | default('en_GB') | escape }}">{{ disclaimer.content | escape }}</disclaimer>
+		<disclaimer lang="{{ disclaimer.lang | default('en_GB') | escape }}">{{ disclaimer.content | escape_xml }}</disclaimer>
 		{% endfor %}
 	</extension>
 </addon>


### PR DESCRIPTION
## Description

This PR overrides the XML escaping to avoid conflicts with the sync language script.

Jinja seems to escape XML with numeric references, presumably to handle the wider array of HTML escape sequences.

To make generation consistent with the translation sync workflow, we'll implement our own custom XML escaper that handles the five relevant characters.

## How has this been tested?

Full run of add-ons with this change:

https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=680&view=logs