### PR TITLE
Update to msys2 2021-07-25

### DIFF
--- a/templates/addon/depends/windows/mingw/03-use-curl.patch.j2
+++ b/templates/addon/depends/windows/mingw/03-use-curl.patch.j2
@@ -1,13 +1,11 @@
 {% if not makefile.cmake %}
---- a/etc/pacman.conf	Fri Jul 15 02:58:59 2016
-+++ b/etc/pacman.conf	Tue Oct 20 20:36:28 2020
-@@ -15,7 +15,7 @@
- #LogFile     = /var/log/pacman.log
- #GPGDir      = /etc/pacman.d/gnupg/
- HoldPkg      = pacman
--#XferCommand = /usr/bin/curl -C - -f %u > %o
-+XferCommand = /usr/bin/curl -k --retry 5 -L -C - -f %u > %o
+--- a/etc/pacman.conf	Fri Oct 25 00:00:00 2021
++++ b/etc/pacman.conf	Tue Jul 18 16:56:49 2022
+@@ -17,6 +17,7 @@
+ HoldPkg     = pacman
+ #XferCommand = /usr/bin/curl -L -C - -f -o %o %u
  #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
++XferCommand = /usr/bin/curl -k --retry 5 -L -C - -f -o %o %u
  #CleanMethod = KeepInstalled
- #UseDelta    = 0.7
+ Architecture = auto
 {% endif %}

--- a/templates/addon/depends/windows/mingw/CMakeLists.txt.j2
+++ b/templates/addon/depends/windows/mingw/CMakeLists.txt.j2
@@ -2,13 +2,14 @@
 cmake_minimum_required(VERSION 3.5)
 project(mingw)
 
-foreach(repo msys mingw32 mingw64)
-  if(${repo} STREQUAL msys)
-    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/etc/pacman.d/mirrorlist.${repo} "Server = http://mirrors.kodi.tv/build-deps/win32/msys2/repos/${repo}2/$arch\n")
-  else()
-    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/etc/pacman.d/mirrorlist.${repo} "Server = http://mirrors.kodi.tv/build-deps/win32/msys2/repos/${repo}\n")
-  endif()
-endforeach()
+# TODO: Upload msys2 packages to mirrors
+#foreach(repo msys mingw32 mingw64)
+#  if(${repo} STREQUAL msys)
+#    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/etc/pacman.d/mirrorlist.${repo} "Server = http://mirrors.kodi.tv/build-deps/win32/msys2/repos/${repo}2/$arch\n")
+#  else()
+#    file(WRITE ${CMAKE_CURRENT_SOURCE_DIR}/etc/pacman.d/mirrorlist.${repo} "Server = http://mirrors.kodi.tv/build-deps/win32/msys2/repos/${repo}\n")
+#  endif()
+#endforeach()
 
 include(CheckSymbolExists)
 check_symbol_exists(_X86_ "Windows.h" _X86_)

--- a/templates/addon/depends/windows/mingw/mingw.sha256.j2
+++ b/templates/addon/depends/windows/mingw/mingw.sha256.j2
@@ -1,3 +1,3 @@
 {% if not makefile.cmake %}
-bb1f1a0b35b3d96bf9c15092da8ce969a84a134f7b08811292fbc9d84d48c65d
+4013a9d5e51b448343efc24fc6a324cc999bb96b4c01b13a6bd3c661bb5c8a82
 {% endif %}

--- a/templates/addon/depends/windows/mingw/mingw.txt.j2
+++ b/templates/addon/depends/windows/mingw/mingw.txt.j2
@@ -1,3 +1,3 @@
 {% if not makefile.cmake %}
-mingw http://mirrors.kodi.tv/build-deps/win32/msys2/msys2-base-x86_64-20161025.tar.xz
+mingw http://mirrors.kodi.tv/build-deps/win32/msys2/msys2-base-x86_64-20210725.tar.xz
 {% endif %}


### PR DESCRIPTION
## Description

In pursuit of solving our sporadic Windows failures (due to bad mirror while downloading msys2 package), I updated msys2 to the latest version on our mirrors.

We'll need some packages for gcc uploaded to our mirrors. In the meantime, I pointed pacman at the msys2 servers instead of our mirrors. This fixes download issues. Not sure if we should upload gcc packages to our mirrors and re-introduce the reason for the download errors in the first place.

## How has this been tested?

Run of all add-ons: https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=707&view=results