### PR TITLE
Drop tvos-aarch64 platform from Jenkins

### DIFF
--- a/templates/addon/Jenkinsfile.j2
+++ b/templates/addon/Jenkinsfile.j2
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix", platforms: {{ ['android-aarch64', 'android-armv7', 'osx-x86_64', 'tvos-aarch64', 'ubuntu-ppa', 'windows-i686', 'windows-x86_64']|reject("in", libretro_repo.exclude_platforms)|list()|tojson() }})
+buildPlugin(version: "Matrix", platforms: {{ ['android-aarch64', 'android-armv7', 'osx-x86_64', 'ubuntu-ppa', 'windows-i686', 'windows-x86_64']|reject("in", libretro_repo.exclude_platforms)|list()|tojson() }})


### PR DESCRIPTION
## Description

Drops tvos-aarch64 from `Jenkinsfile` because it's failing for many cores.

For all the tvos cores that previously succeeded to build for tvos, they'll remain on the mirrors for testing. They won't need updates for a while.