### PR TITLE
Two fixes

### DIFF
--- a/kodi_game_scripting/libretro_super.py
+++ b/kodi_game_scripting/libretro_super.py
@@ -40,7 +40,10 @@ class LibretroSuper:
         """ Load info file from libretro-super repository """
         path = os.path.join(self._working_directory, 'libretro-super', 'dist',
                             'info', '{}.info'.format(library_soname))
-        result = {}
+        result = {
+            'license': 'Unlicensed',
+        }
+
         if os.path.isfile(path):
             with open(path, 'r') as info_ctx:
                 for line in info_ctx.readlines():

--- a/kodi_game_scripting/process_game_addons.py
+++ b/kodi_game_scripting/process_game_addons.py
@@ -279,6 +279,7 @@ class KodiGameAddon():
             'datetime': '{0:%Y-%m-%d %H:%Mi%z}'.format(
                 datetime.datetime.now()),
             'system_info': {
+                'name': '',
                 'version': '0.0.0',
             },
             'settings': [],


### PR DESCRIPTION
## Description

As title says, this PR contains two fixes that I experienced when creating a new core that did not already exist.

First, when running the CI script with a new core, I got the following error:

```
    File "process_game_addons.py", line 479, in _get_addon_summary
      addon_summary = self.info['system_info']['name']
  KeyError: 'name'
  ```
  
I fixed this by adding a `name` field to the default object.

Next, when running the CI script with a new core, I got the following error:

```
    File "templates/summary/wiki.txt.j2", line 18, in top-level template code
      | License= {{ '{{' }}{{ license_status }}|{{ addon.libretro_info.license.split('|') | join(', ') | default('?') }}{{ '}}' }}
  jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'license'
  ```
  
  I fixed this by adding a `license` field to the default object, with an initial value of `Unlicensed` that is overrided by the appropriate license when the core info exists.

## How has this been tested?

Tested with galaxy (https://github.com/kodi-game/game.libretro.galaxy / https://github.com/libretro/galaxy-libretro), which does not exist in the libretro-super repo.

After (any) testing, this core should be added to the libretro-super repo.

## How has this been tested?

Tested with a full run of all cores: https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=826&view=logs&s=96ac2280-8cb4-5df5-99de-dd2da759617d