### PR TITLE
Add add-on name to README image alt texts for SEO

### DIFF
--- a/templates/addon/README.md.j2
+++ b/templates/addon/README.md.j2
@@ -1,3 +1,4 @@
+{% set addon_name = libretro_info.display_name | default(xml.addon.name) | default(system_info.name) | default(game.name) %}
 [![Build Status](https://travis-ci.org/kodi-game/{{ game.addon }}.svg?branch=master)](https://travis-ci.org/kodi-game/{{ game.addon }})
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/kodi-game/{{ game.addon }}?svg=true)](https://ci.appveyor.com/project/kodi-game/{{ game.addon | regex_replace('[\._]', '-') }})
 
@@ -14,7 +15,7 @@
 ### Icon
 
 {% if assets.icon %}
-![Icon]({{ game.addon }}/{{ assets.icon }})
+![{{ addon_name }} icon]({{ game.addon }}/{{ assets.icon }})
 {% else %}
 Help make me an icon!
 {% endif %}
@@ -22,7 +23,7 @@ Help make me an icon!
 ### Fanart
 
 {% if assets.fanart %}
-![Fanart]({{ game.addon }}/{{ assets.fanart }})
+![{{ addon_name }} fanart]({{ game.addon }}/{{ assets.fanart }})
 {% else %}
 Help make me fanart!
 {% endif %}
@@ -31,7 +32,7 @@ Help make me fanart!
 
 {% if assets.screenshots %}
 {% for screenshot in assets.screenshots %}
-![Screenshot]({{ game.addon }}/{{ screenshot }})
+![{{ addon_name }} screenshot]({{ game.addon }}/{{ screenshot }})
 {% endfor %}
 {% else %}
 Help make me screenshots!


### PR DESCRIPTION
## Description

This PR gives the emulator artwork in the README (added in https://github.com/kodi-game/kodi-game-scripting/pull/103) an alt text that can be indexed by Google, allowing for the artwork to be discoverable in Google image search.

## Motivation and context

I had the idea when I was searching for icons for the remaining cores. Some of the results were icons on the documentation pages of other projects. It'd be cool if our artwork can be used in the same way.

## How has this been tested?

### 2048

I tested 2048 because it has all available 

Commit: https://github.com/kodi-game/game.libretro.2048/commit/9555a69aec1f08174a5b6edb331a8b5c2e70d9a9

Before:

```html
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/icon.png" alt="Icon" style="max-width: 100%;">
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/fanart.jpg" alt="Fanart" style="max-width: 100%;">
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/screenshot-01.jpg" alt="Screenshot" style="max-width: 100%;">
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/screenshot-02.jpg" alt="Screenshot" style="max-width: 100%;">
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/screenshot-03.jpg" alt="Screenshot" style="max-width: 100%;">
```

After:

```html
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/icon.png" alt="2048 icon" style="max-width: 100%;">
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/fanart.jpg" alt="2048 fanart" style="max-width: 100%;">
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/screenshot-01.jpg" alt="2048 screenshot" style="max-width: 100%;">
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/screenshot-02.jpg" alt="2048 screenshot" style="max-width: 100%;">
<img src="/kodi-game/game.libretro.2048/raw/master/game.libretro.2048/resources/screenshot-03.jpg" alt="2048 screenshot" style="max-width: 100%;">
```

### Reminisence

I tested Reminiscence because it has a more complicated add-on name than "2048".

Commit: https://github.com/kodi-game/game.libretro.reminiscence/commit/8094b847c1af754e96122b2b411ea86477b1be4a

Before:

```html
<img src="/kodi-game/game.libretro.reminiscence/raw/master/game.libretro.reminiscence/resources/icon.png" alt="Icon" style="max-width: 100%;">
```

After:

```html
<img src="/kodi-game/game.libretro.reminiscence/raw/master/game.libretro.reminiscence/resources/icon.png" alt="Flashback (REminiscence) icon" style="max-width: 100%;">
```