### PR TITLE
Use Nexus branch for Jenkins

### DIFF
--- a/kodi_game_scripting/process_game_addons.py
+++ b/kodi_game_scripting/process_game_addons.py
@@ -464,7 +464,7 @@ class KodiGameAddon():
         """ Creating tags in Git repository """
         print("  Creating tags in Git repository {}: {}".format(
             self.name, self.info['game']['version']))
-        for branch in ['Matrix']:
+        for branch in ['Nexus']:
             self._repo.tag('{}-{}'.format(self.info['game']['version'], branch))
 
     def push(self):

--- a/templates/addon/Jenkinsfile.j2
+++ b/templates/addon/Jenkinsfile.j2
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix", platforms: {{ ['android-aarch64', 'android-armv7', 'osx-x86_64', 'ubuntu-ppa', 'windows-i686', 'windows-x86_64']|reject("in", libretro_repo.exclude_platforms)|list()|tojson() }})
+buildPlugin(version: "Nexus", platforms: {{ ['android-aarch64', 'android-armv7', 'osx-x86_64', 'ubuntu-ppa', 'windows-i686', 'windows-x86_64']|reject("in", libretro_repo.exclude_platforms)|list()|tojson() }})


### PR DESCRIPTION
## Description

As title says, this freezes the `Matrix` add-ons at their last round of translation/icon updates in late-January, and moves all add-ons to the `Nexus` branch.

Required to fix Android and macOS builds when the Android builder migrated to ndk 21b in the last few weeks.

## How has this been tested?

Before, failed Jenkins run: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.fceumm/detail/0.0.1.42-Matrix/1/pipeline

After, successful Jenkins run: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.fceumm/detail/master/122/pipeline