### PR TITLE
Remove version from summary

### DIFF
--- a/kodi_game_scripting/process_game_addons.py
+++ b/kodi_game_scripting/process_game_addons.py
@@ -365,7 +365,14 @@ class KodiGameAddon():
             print("Failed to read output library.")
 
         # Update summary for loaded info
-        self.info['game']['summary'] = self._get_addon_summary()
+        summary_english = self._get_addon_summary()
+
+        self.info['game']['summary'] = summary_english
+        self.info['game']['summary_english'] = summary_english
+
+        for string_tag in self.info['game']['summaries']:
+            if 'lang' not in string_tag or string_tag['lang'].lower() in ['en', 'en_gb']:
+                string_tag['content'] = summary_english
 
         return library
 

--- a/kodi_game_scripting/process_game_addons.py
+++ b/kodi_game_scripting/process_game_addons.py
@@ -481,9 +481,4 @@ class KodiGameAddon():
         if not addon_summary:
             addon_summary = self.game_name
 
-        # Append stylized version
-        addon_version = self.info["system_info"]["version"]
-        if addon_version:
-            addon_summary += ' ' + addon_version
-
         return addon_summary


### PR DESCRIPTION
## Description

While splitting the Vice cores I noticed that when the add-on name/version changed, the summary wasn't updated - it uses the existing summary string instead of "generating" a new one with the up-to-date name and version.

However, even sporadic string updates can wreak havoc on an unsuspecting weblate, so best to remove version from the summary string entirely.

## How has this been tested?

In the process of rolling out to all add-ons.

Example commits:

* kodi-game-scripting update: https://github.com/kodi-game/game.libretro.yabause/commit/f0f862ca961dc8e037106e500130d06cf7ced549

* weblate update - https://github.com/kodi-game/game.libretro.yabause/commit/5cce0c0ba354aa696b22daabafc7d09daf5298f8

* Sync workflow update - https://github.com/kodi-game/game.libretro.yabause/commit/962e30b5ddc4206fe5e9d78d1db64e33ef1d872f