### PR TITLE
Add beetle-psx-hw core

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,9 @@ jobs:
         # 3dengine
         dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
 
+        # beetle-psx-hw
+        dpkg -s libgl-dev || sudo apt install libgl-dev
+
         # boom3
         dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
 
@@ -303,6 +306,7 @@ jobs:
           - beetle-vb
           - beetle-supergrafx
           - beetle-saturn
+          - beetle-psx-hw
           - beetle-psx
           - beetle-pcfx
           - beetle-pce-fast

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -39,6 +39,7 @@ ADDONS = {
     'beetle-pce-fast':           ('beetle-pce-fast-libretro',   'Makefile',          '.',                 'jni', {'soname': 'mednafen_pce_fast'}),
     'beetle-pcfx':               ('beetle-pcfx-libretro',       'Makefile',          '.',                 'jni', {'soname': 'mednafen_pcfx'}),
     'beetle-psx':                ('beetle-psx-libretro',        'Makefile',          '.',                 'jni', {'soname': 'mednafen_psx'}),
+    'beetle-psx-hw':             ('beetle-psx-libretro',        'Makefile',          '.',                 'jni', {'soname': 'mednafen_psx_hw', 'cmake_options': 'HAVE_OPENGL=1'}),
     'beetle-saturn':             ('beetle-saturn-libretro',     'Makefile',          '.',                 'jni', {'soname': 'mednafen_saturn'}),
     'beetle-supergrafx':         ('beetle-supergrafx-libretro', 'Makefile',          '.',                 'jni', {'soname': 'mednafen_supergrafx'}),
     'beetle-vb':                 ('beetle-vb-libretro',         'Makefile',          '.',                 'jni', {'soname': 'mednafen_vb'}),


### PR DESCRIPTION
## Description

Adds new beetle-psx-hw core.

## Motivation and context

See comment here: https://github.com/kodi-game/game.libretro.beetle-psx/pull/19#issuecomment-1529992242

## How has this been tested?

CI run: https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=1182&view=logs&j=b724a4ce-d971-5e6e-9f98-76134d834be3

Generated https://github.com/kodi-game/game.libretro.beetle-psx-hw