### PR TITLE
Preserve string IDs

### DIFF
--- a/templates/addon/{{ game.addon }}/resources/language/resource.language.en_gb/strings.po.j2
+++ b/templates/addon/{{ game.addon }}/resources/language/resource.language.en_gb/strings.po.j2
@@ -29,15 +29,15 @@ msgctxt "Addon Disclaimer"
 msgid "{{ regex_replace(game.disclaimer_english, '"', '\\"') }}"
 msgstr ""
 {% endif %}
-{% if settings %}
+{% if strings %}
 
 msgctxt "#30000"
 msgid "Settings"
 msgstr ""
-{% for setting in settings %}
+{% for string in strings %}
 
-msgctxt "#{{ 30000 + loop.index }}"
-msgid "{{ regex_replace(setting.description, '"', '\\"') }}"
+msgctxt "#{{ string.id }}"
+msgid "{{ regex_replace(string.content, '"', '\\"') }}"
 msgstr ""
 {% endfor %}
 {% endif %}

--- a/templates/addon/{{ game.addon }}/resources/settings.xml.j2
+++ b/templates/addon/{{ game.addon }}/resources/settings.xml.j2
@@ -3,7 +3,7 @@
 <settings>
 	<category label="30000">
 	{% for setting in settings %}
-		<setting label="{{ 30000 + loop.index }}" type="select" id="{{ setting.id | e }}" values="{{ setting['values']|join('|') | e }}" default="{{ setting.default | e }}"/>
+		<setting label="{{ setting.label }}" type="select" id="{{ setting.id | e }}" values="{{ setting['values']|join('|') | e }}" default="{{ setting.default | e }}"/>
 	{% endfor %}
 	</category>
 </settings>


### PR DESCRIPTION
## Description

Previously, when a string in the middle of the settings changed, all subsequent strings would get new IDs, wreaking havoc on weblate.

Now, string IDs are preserved, and new strings are added to the end of strings.po.

## How has this been tested?

Tested with UAE, see success: https://github.com/kodi-game/game.libretro.uae/commit/testing

Another success with vice_x64: https://github.com/kodi-game/game.libretro.vice_x64/commit/70a16dcdfe18ed2fc84dcc0250cd75fc14f25824