### PR TITLE
Add yabasanshiro core

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -139,6 +139,9 @@ jobs:
 
         # wolfenstein3d
         #dpkg -s libsdl1.2-dev || sudo apt install -y libsdl1.2-dev
+
+        # yabasanshiro
+        dpkg -s mesa-common-dev || sudo apt install -y mesa-common-dev
       displayName: 'Install system dependencies'
 
     # TODO: git authorship
@@ -164,6 +167,7 @@ jobs:
         # List add-ons in reverse order for sorted results in the kodi-game org
         addons:
           - yabause
+          - yabasanshiro
           - xrick
           - xmil
           #- wolfenstein3d # Doesn't compile

--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -183,5 +183,6 @@ ADDONS = {
     #'wolfenstein3d':             ('kodi-game/libretro-wolfenstein3d', 'Makefile.libretro', '.',           'jni', {}),  # Requires SDL 1
     'xmil':                      ('xmil-libretro',              'Makefile.libretro', 'libretro',          'libretro/jni', {'soname': 'x1'}),
     'xrick':                     ('xrick-libretro',             'Makefile.libretro', '.',                 'jni', {}),
+    'yabasanshiro':              ('yabause',                    'Makefile',          'yabause/src/libretro', 'yabause/src/libretro/jni', {'branch': 'yabasanshiro'}),
     'yabause':                   ('yabause',                    'Makefile',          'yabause/src/libretro', 'yabause/src/libretro/jni', {}),
 }


### PR DESCRIPTION
## Description

This PR adds the yabasanshiro core, based on yabause. Requested here: https://github.com/kodi-game/game.libretro/issues/97

I got it to build and generate the add-on files correctly. However, I'll hold off on adding it to jenkins and the mirrors until we have OpenGL support.

## How has this been tested?

Generated https://github.com/kodi-game/game.libretro.yabasanshiro