### PR TITLE
Update scummvm to master branch

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -155,7 +155,7 @@ ADDONS = {
     #'rustation':                 ('rustation-libretro',         'Makefile',          '.',                 'jni', {}),  # Checkout fails
     'same_cdi':                  ('same_cdi',                   'Makefile.libretro', '.',                 'jni', {}),
     'sameboy':                   ('SameBoy',                    'Makefile',          'libretro',          'libretro/jni', {'branch': 'buildbot'}),
-    'scummvm':                   ('libretro/scummvm-wrapper',   'Makefile',          '.',                 'jni', {'branch': 'main'}),
+    'scummvm':                   ('scummvm',                    'Makefile',          'backends/platform/libretro', 'backends/platform/libretro/jni', {}),
     'smsplus-gx':                ('smsplus-gx',                 'Makefile.libretro', '.',                 'jni', {'soname': 'smsplus'}),
     'snes9x':                    ('snes9x',                     'Makefile',          'libretro',          'libretro/jni', {}),
     'snes9x2002':                ('snes9x2002',                 'Makefile',          '.',                 'jni', {}),


### PR DESCRIPTION
## Description

As title says, this switches back from the wrapper to the libretro upstream.

Requires https://github.com/kodi-game/game.libretro.scummvm/pull/27

## Motivation and Context

ScummVM originally worked when it was introduced at version 1.8.0 in 2016 in https://github.com/kodi-game/game.libretro.scummvm/pull/1

In 2021, I got themes and extras to work: https://github.com/kodi-game/game.libretro.scummvm/pull/25

In 2023, I updated ScummVM from v2.6 to v2.7, and switched it to use a libretro wrapper repo introduced to wrap the latest scummvm: https://github.com/kodi-game/kodi-game-scripting/pull/115

However, the wrapper repo was discontinued and has been deleted, so we can't even build scummvm anymore.

## How has this been tested?

CI run: https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=1519&view=results