### PR TITLE
Fix building add-ons with Kodi using C++20

### DIFF
--- a/templates/addon/CMakeLists.txt.j2
+++ b/templates/addon/CMakeLists.txt.j2
@@ -5,6 +5,8 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
 
+set(CMAKE_CXX_STANDARD 17)
+
 # CMake on windows only searches for .lib libraries (static library or import library).
 # The libretro game library is dynamically loaded so even if an import library would exists it's of no use.
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)


### PR DESCRIPTION
## Description

Set CMAKE_CXX_STANDARD to 17 in the addon root CMakelists.txt to override master forcing c++20.

CC @fuzzard 