### PR TITLE
Fix building for Intel macs

### DIFF
--- a/templates/addon/depends/common/{{ game.name }}/CMakeLists.txt.j2
+++ b/templates/addon/depends/common/{{ game.name }}/CMakeLists.txt.j2
@@ -49,6 +49,9 @@ elseif(CORE_SYSTEM_NAME STREQUAL osx)
                     -f {{ makefile.file }}
                     platform=osx
                     arch=${ARCH}
+                    CROSS_COMPILE=1
+                    LIBRETRO_APPLE_PLATFORM=${CPU}-apple-macos
+                    LIBRETRO_APPLE_ISYSROOT=${CMAKE_OSX_SYSROOT}
                     {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=)
 elseif(CORE_SYSTEM_NAME STREQUAL ios OR CORE_SYSTEM_NAME STREQUAL darwin_embedded)
   if(CORE_PLATFORM_NAME STREQUAL ios)

--- a/templates/addon/depends/common/{{ game.name }}/CMakeLists.txt.j2
+++ b/templates/addon/depends/common/{{ game.name }}/CMakeLists.txt.j2
@@ -23,16 +23,33 @@ if(CORE_SYSTEM_NAME STREQUAL windows)
   else()
     set(MSYSTEM MINGW32)
   endif()
-  set(BUILD_COMMAND ${MINGW_MAKE} -j$ENV{NUMBER_OF_PROCESSORS} -C {{ makefile.dir }} -f {{ makefile.file }} platform=win MSYSTEM=${MSYSTEM} {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=)
+  set(BUILD_COMMAND ${MINGW_MAKE}
+                    -j$ENV{NUMBER_OF_PROCESSORS}
+                    -C {{ makefile.dir }}
+                    -f {{ makefile.file }}
+                    platform=win
+                    MSYSTEM=${MSYSTEM}
+                    {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=)
 elseif(CORE_SYSTEM_NAME STREQUAL linux)
-  set(BUILD_COMMAND $(MAKE) -C {{ makefile.dir }} -f {{ makefile.file }} {{ config.cmake_options | default('') }} platform=unix ${LIBRETRO_DEBUG} GIT_VERSION=)
+  set(BUILD_COMMAND $(MAKE)
+                    -j
+                    -C {{ makefile.dir }}
+                    -f {{ makefile.file }}
+                    platform=unix
+                    {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=)
 elseif(CORE_SYSTEM_NAME STREQUAL osx)
   if(CPU STREQUAL arm64)
     set(ARCH arm)
   else()
     set(ARCH intel)
   endif()
-  set(BUILD_COMMAND $(MAKE) -C {{ makefile.dir }} -f {{ makefile.file }} {{ config.cmake_options | default('') }} platform=osx arch=${ARCH} ${LIBRETRO_DEBUG} GIT_VERSION=)
+  set(BUILD_COMMAND $(MAKE)
+                    -j
+                    -C {{ makefile.dir }}
+                    -f {{ makefile.file }}
+                    platform=osx
+                    arch=${ARCH}
+                    {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=)
 elseif(CORE_SYSTEM_NAME STREQUAL ios OR CORE_SYSTEM_NAME STREQUAL darwin_embedded)
   if(CORE_PLATFORM_NAME STREQUAL ios)
     set(LIBRETRO_SONAME {{ library.soname }}_ios${CMAKE_SHARED_LIBRARY_SUFFIX})
@@ -41,10 +58,20 @@ elseif(CORE_SYSTEM_NAME STREQUAL ios OR CORE_SYSTEM_NAME STREQUAL darwin_embedde
     else()
       set(PLATFORM ios)
     endif()
-    set(BUILD_COMMAND IOSSDK=${CMAKE_OSX_SYSROOT} $(MAKE) -C {{ makefile.dir }} -f {{ makefile.file }} {{ config.cmake_options | default('') }} platform=${PLATFORM} ${LIBRETRO_DEBUG} GIT_VERSION=)
+    set(BUILD_COMMAND IOSSDK=${CMAKE_OSX_SYSROOT} $(MAKE)
+                                                  -j
+                                                  -C {{ makefile.dir }}
+                                                  -f {{ makefile.file }}
+                                                  platform=${PLATFORM}
+                                                  {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=)
   elseif(CORE_PLATFORM_NAME STREQUAL tvos)
     set(LIBRETRO_SONAME {{ library.soname }}_tvos${CMAKE_SHARED_LIBRARY_SUFFIX})
-    set(BUILD_COMMAND IOSSDK=${CMAKE_OSX_SYSROOT} $(MAKE) -C {{ makefile.dir }} -f {{ makefile.file }} {{ config.cmake_options | default('') }} platform=tvos-arm64 ${LIBRETRO_DEBUG} GIT_VERSION=)
+    set(BUILD_COMMAND IOSSDK=${CMAKE_OSX_SYSROOT} $(MAKE)
+                                                  -j
+                                                  -C {{ makefile.dir }}
+                                                  -f {{ makefile.file }}
+                                                  platform=tvos-arm64
+                                                  {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=)
   endif()
 elseif(CORE_SYSTEM_NAME STREQUAL android)
   if(NOT NDKROOT)
@@ -59,8 +86,13 @@ elseif(CORE_SYSTEM_NAME STREQUAL android)
   else()
     message(FATAL_ERROR "${PROJECT_NAME} needs Android ${CPU} build command in CMakeLists.txt!")
   endif()
-  set(BUILD_COMMAND GNUMAKE=$(MAKE) ${NDKROOT}/ndk-build -C {{ makefile.jni }} APP_ABI=${PLATFORM} V7NEONOPTIMIZATION=1 GIT_VERSION=
-                                    NDK_LIBS_OUT=${PROJECT_SOURCE_DIR}/${LIBRETRO_BINARY_DIR} {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} V=1
+  set(BUILD_COMMAND GNUMAKE=$(MAKE) ${NDKROOT}/ndk-build
+                                    -C {{ makefile.jni }}
+                                    APP_ABI=${PLATFORM}
+                                    V7NEONOPTIMIZATION=1
+                                    NDK_LIBS_OUT=${PROJECT_SOURCE_DIR}/${LIBRETRO_BINARY_DIR}
+                                    V=1
+                                    {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=
                     && cp ${PROJECT_SOURCE_DIR}/${LIBRETRO_BINARY_DIR}/${PLATFORM}/${LIBRETRO_JNISONAME} ${PROJECT_SOURCE_DIR}/${LIBRETRO_BINARY_DIR}/${LIBRETRO_SONAME})
   {% else %}
   if(CPU STREQUAL armeabi-v7a)
@@ -72,12 +104,22 @@ elseif(CORE_SYSTEM_NAME STREQUAL android)
   endif()
   set(LIBRETRO_SONAME {{ library.soname }}_android${CMAKE_SHARED_LIBRARY_SUFFIX})
   get_filename_component(TOOLCHAIN_DIR ${CMAKE_C_COMPILER} DIRECTORY)
-  set(BUILD_COMMAND PATH=${TOOLCHAIN_DIR}:$ENV{PATH} $(MAKE) -C {{ makefile.dir }} -f {{ makefile.file }} {{ config.cmake_options | default('') }} platform=${PLATFORM} ${LIBRETRO_DEBUG} GIT_VERSION=)
+  set(BUILD_COMMAND PATH=${TOOLCHAIN_DIR}:$ENV{PATH} $(MAKE)
+                                                     -j
+                                                     -C {{ makefile.dir }}
+                                                     -f {{ makefile.file }}
+                                                     platform=${PLATFORM}
+                                                     {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=)
   {% endif %}
 elseif(CORE_SYSTEM_NAME STREQUAL rbpi)
   message(FATAL_ERROR "${PROJECT_NAME} needs RPi build command in CMakeLists.txt!")
 elseif(CORE_SYSTEM_NAME STREQUAL freebsd)
-  set(BUILD_COMMAND $(MAKE) -C {{ makefile.dir }} -f {{ makefile.file }} {{ config.cmake_options | default('') }} platform=unix ${LIBRETRO_DEBUG} GIT_VERSION=)
+  set(BUILD_COMMAND $(MAKE)
+                    -j
+                    -C {{ makefile.dir }}
+                    -f {{ makefile.file }}
+                    platform=unix
+                    {{ config.cmake_options | default('') }} ${LIBRETRO_DEBUG} GIT_VERSION=)
 else()
   message(FATAL_ERROR "${PROJECT_NAME} - Unknown system: ${CORE_SYSTEM_NAME}")
 endif()


### PR DESCRIPTION
## Description

Currently, many cores generate arm binaries when building for intel on macos.

This PR applies the de-facto flags used by libretro to set macOS build flags.

CC @fuzzard 