### PR TITLE
Build cores in parellel

### DIFF
--- a/templates/addon/depends/common/{{ game.name }}/CMakeLists.txt.j2
+++ b/templates/addon/depends/common/{{ game.name }}/CMakeLists.txt.j2
@@ -8,6 +8,21 @@ include(ExternalProject)
 
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UC)
 
+# Jenkins CI jobs can have this env var set
+# Use it if available
+if(DEFINED ENV{BUILDTHREADS})
+  set(build_job_count -j$ENV{BUILDTHREADS})
+  message(STATUS "Using $ENV{BUILDTHREADS} threads from ENV var BUILDTHREADS")
+else()
+  # Most likely a non CI build, so do a best attempt just using ProcessorCount
+  include(ProcessorCount)
+  ProcessorCount(cpu_count)
+  if(NOT cpu_count EQUAL 0)
+    set(build_job_count -j${cpu_count})
+    message(STATUS "Using ${cpu_count} threads deduced by ProcessorCount")
+  endif()
+endif()
+
 set(LIBRETRO_BINARY_DIR {{ config.binary_dir | default(makefile.dir) }})
 set(LIBRETRO_SONAME {{ library.soname }}${CMAKE_SHARED_LIBRARY_SUFFIX})
 set(LIBRETRO_JNISONAME {{ library.jnisoname }}${CMAKE_SHARED_LIBRARY_SUFFIX})
@@ -24,9 +39,9 @@ if(CORE_SYSTEM_NAME STREQUAL windows)
     set(MSYSTEM MINGW32)
   endif()
   set(BUILD_COMMAND ${MINGW_MAKE}
-                    -j$ENV{NUMBER_OF_PROCESSORS}
                     -C {{ makefile.dir }}
                     -f {{ makefile.file }}
+                    ${build_job_count}
                     ${LIBRETRO_DEBUG}
                     GIT_VERSION=
                     MSYSTEM=${MSYSTEM}
@@ -36,6 +51,7 @@ elseif(CORE_SYSTEM_NAME STREQUAL linux)
   set(BUILD_COMMAND $(MAKE)
                     -C {{ makefile.dir }}
                     -f {{ makefile.file }}
+                    ${build_job_count}
                     ${LIBRETRO_DEBUG}
                     GIT_VERSION=
                     platform=unix
@@ -49,6 +65,7 @@ elseif(CORE_SYSTEM_NAME STREQUAL osx)
   set(BUILD_COMMAND $(MAKE)
                     -C {{ makefile.dir }}
                     -f {{ makefile.file }}
+                    ${build_job_count}
                     ${LIBRETRO_DEBUG}
                     arch=${ARCH}
                     CROSS_COMPILE=1
@@ -68,6 +85,7 @@ elseif(CORE_SYSTEM_NAME STREQUAL ios OR CORE_SYSTEM_NAME STREQUAL darwin_embedde
     set(BUILD_COMMAND IOSSDK=${CMAKE_OSX_SYSROOT} $(MAKE)
                                                   -C {{ makefile.dir }}
                                                   -f {{ makefile.file }}
+                                                  ${build_job_count}
                                                   ${LIBRETRO_DEBUG}
                                                   GIT_VERSION=
                                                   platform=${PLATFORM}
@@ -77,6 +95,7 @@ elseif(CORE_SYSTEM_NAME STREQUAL ios OR CORE_SYSTEM_NAME STREQUAL darwin_embedde
     set(BUILD_COMMAND IOSSDK=${CMAKE_OSX_SYSROOT} $(MAKE)
                                                   -C {{ makefile.dir }}
                                                   -f {{ makefile.file }}
+                                                  ${build_job_count}
                                                   ${LIBRETRO_DEBUG}
                                                   GIT_VERSION=
                                                   platform=tvos-arm64
@@ -97,6 +116,7 @@ elseif(CORE_SYSTEM_NAME STREQUAL android)
   endif()
   set(BUILD_COMMAND GNUMAKE=$(MAKE) ${NDKROOT}/ndk-build
                                     -C {{ makefile.jni }}
+                                    ${build_job_count}
                                     ${LIBRETRO_DEBUG}
                                     APP_ABI=${PLATFORM}
                                     APP_SHORT_COMMANDS=true
@@ -119,6 +139,7 @@ elseif(CORE_SYSTEM_NAME STREQUAL android)
   set(BUILD_COMMAND PATH=${TOOLCHAIN_DIR}:$ENV{PATH} $(MAKE)
                                                      -C {{ makefile.dir }}
                                                      -f {{ makefile.file }}
+                                                     ${build_job_count}
                                                      ${LIBRETRO_DEBUG}
                                                      GIT_VERSION=
                                                      platform=${PLATFORM}
@@ -130,6 +151,7 @@ elseif(CORE_SYSTEM_NAME STREQUAL freebsd)
   set(BUILD_COMMAND $(MAKE)
                     -C {{ makefile.dir }}
                     -f {{ makefile.file }}
+                    ${build_job_count}
                     ${LIBRETRO_DEBUG}
                     GIT_VERSION=
                     platform=unix


### PR DESCRIPTION
## Description

This PR modifies the core's CMakeLists.txt file to add the parallel -j flag to the build command.

Credit to @fuzzard.

## How has this been tested?

Ran locally on my workstation:

```
[ 29%] Performing configure step for 'scummvm'
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using 16 threads deduced by ProcessorCount
-- Configuring done
-- Generating done
```

* "Using 16 threads deduced by ProcessorCount" appears in the output.

Ran on ScummVM. Jenkins results: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.scummvm/detail/2.9.0.44-Omega/1/pipeline