### PR TITLE
config: Excluded 'android-armv7' platform from vba-next

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -171,7 +171,7 @@ ADDONS = {
     'uae':                       ('libretro-uae',               'Makefile',          '.',                 'jni', {'soname': 'puae'}),
     #'uae4arm':                   ('Chips-fr/uae4arm-rpi',       'Makefile.libretro', '.',                 'jni', {}),  # Fails to build on non arm system
     'uzem':                      ('libretro-uzem',              'Makefile.libretro', '.',                 'jni', {}),
-    'vba-next':                  ('vba-next',                   'Makefile',          '.',                 'libretro/jni', {'soname': 'vba_next'}),
+    'vba-next':                  ('vba-next',                   'Makefile',          '.',                 'libretro/jni', {'soname': 'vba_next', 'exclude_platforms': ['android-armv7']}),
     'vbam':                      ('visualboyadvance-m/visualboyadvance-m', 'Makefile', 'src/libretro',    'src/libretro/jni', {}),
     'vecx':                      ('libretro-vecx',              'Makefile',          '.',                 'jni', {}),
     'vemulator':                 ('vemulator-libretro',         'Makefile',          '.',                 'jni', {}),


### PR DESCRIPTION
## Description

This PR excludes the  `android-armv7` platform from vba-next due to a build error.

Build error was:

```
/ndk-release-r21/bionic/libc/bionic/locale.cpp:136: error: undefined reference to 'operator new(unsigned int)'
/ndk-release-r21/bionic/libc/bionic/locale.cpp:140: error: undefined reference to 'operator delete(void*)'
/ndk-release-r21/bionic/libc/bionic/locale.cpp:155: error: undefined reference to 'operator new(unsigned int)'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

## How has this been tested?

After applying the patch, vba-next goes green on all other supported platforms: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.vba-next/detail/master/143/pipeline