### PR TITLE
config: Exclude 'osx-x86_64' and 'osx-arm64' for supafaust

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -162,7 +162,7 @@ ADDONS = {
     'snes9x2002':                ('snes9x2002',                 'Makefile',          '.',                 'jni', {}),
     'snes9x2010':                ('snes9x2010',                 'Makefile',          '.',                 'jni', {}),
     'stella':                    ('stella-emu/stella',          'Makefile',          'src/os/libretro',   'src/os/libretro/jni', {}),
-    'supafaust':                 ('supafaust',                  'Makefile',          '.',                 'jni', {'soname': 'mednafen_supafaust'}),
+    'supafaust':                 ('supafaust',                  'Makefile',          '.',                 'jni', {'soname': 'mednafen_supafaust', 'exclude_platforms': ['osx-x86_64', 'osx-arm64']}),
     'swanstation':               ('swanstation',                '',                  '.',                 '', {'branch': 'main', 'cmake': True}),
     'tgbdual':                   ('tgbdual-libretro',           'Makefile',          '.',                 'jni', {}),
     'theodore':                  ('Zlika/theodore',             'Makefile',          '.',                 'jni', {}),


### PR DESCRIPTION
## Description

Similar to https://github.com/kodi-game/kodi-game-scripting/pull/130, this PR adds excluded platforms that supafaust has failed to build on since the beginning.

This is due to Beetle Supafaust not compiling on macOS versions since Big Sur (version 11.0).

Errors are:

```
mednafen/mthreading/MThreading_POSIX.cpp:585:5: error: use of undeclared identifier 'sem_timedwait'; did you mean Sem_TimedWait'?
 if(sem_timedwait(&sem->s, &abstime))
    ^~~~~~~~~~~~~
    Sem_TimedWait

mednafen/mthreading/MThreading_POSIX.cpp:585:19: error: cannot initialize a parameter of type 'Mednafen::MThreading::Sem *with an rvalue of type 'sem_t *' (aka 'int *')
 if(sem_timedwait(&sem->s, &abstime))
                  ^~~~~~~
```

## How has this been tested?

Build succeeds on remaining platforms (win/android): https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.supafaust/detail/master/117/pipeline