### PR TITLE
Rename single settings category from "Settings" to "General"

### DIFF
--- a/templates/addon/{{ game.addon }}/resources/language/resource.language.en_gb/strings.po.j2
+++ b/templates/addon/{{ game.addon }}/resources/language/resource.language.en_gb/strings.po.j2
@@ -30,10 +30,6 @@ msgid "{{ regex_replace(game.disclaimer_english, '"', '\\"') }}"
 msgstr ""
 {% endif %}
 {% if strings %}
-
-msgctxt "#30000"
-msgid "Settings"
-msgstr ""
 {% for string in strings %}
 
 msgctxt "#{{ string.id }}"

--- a/templates/addon/{{ game.addon }}/resources/settings.xml.j2
+++ b/templates/addon/{{ game.addon }}/resources/settings.xml.j2
@@ -1,7 +1,7 @@
 {% if settings %}
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-	<category label="30000">
+	<category label="128">
 	{% for setting in settings %}
 		<setting label="{{ setting.label }}" type="select" id="{{ setting.id | e }}" values="{{ setting['values']|join('|') | e }}" default="{{ setting.default | e }}"/>
 	{% endfor %}


### PR DESCRIPTION
## Description

This PR renames the main (and only) settings category from "Settings" to "General".

"Settings"  already appears on the screen in the dialog title. "General" is a better label and is more consistent with the rest of Kodi.

## Motivation and context

Noticed by @jjd-uk here: https://github.com/xbmc/xbmc/pull/25598#issuecomment-2296998113

## How has this been tested?

### Locally

I modified a local add-on by hand. Tested in the Advanced Settings in-game dialog.

Before:

![screenshot00001](https://github.com/user-attachments/assets/ca90ac6d-ea0f-482d-bdfe-d00d86ca9013)

After:

![screenshot00000](https://github.com/user-attachments/assets/e103ada8-3afd-48e4-b831-fa34b2592418)

### Azure CI script

I ran the Azure CI script on Yabause and it pushed a new version (0.9.15.61) to the repo. Jenkins picked up the new version and uploaded binaries to the mirrors. Tested in the add-on browser.

Before:

TODO

After:

TODO: Take a screenshot when the update deploys in 24 hr