### PR TITLE
Change swanstation to kodi-game org repo

### DIFF
--- a/kodi_game_scripting/config.py
+++ b/kodi_game_scripting/config.py
@@ -154,7 +154,7 @@ ADDONS = {
     'snes9x2010':                ('snes9x2010',                 'Makefile',          '.',                 'jni', {}),
     'stella':                    ('stella-emu/stella',          'Makefile',          'src/os/libretro',   'src/os/libretro/jni', {}),
     'supafaust':                 ('supafaust',                  'Makefile',          '.',                 'jni', {'soname': 'mednafen_supafaust', 'exclude_platforms': ['osx-x86_64', 'osx-arm64']}),
-    'swanstation':               ('swanstation',                '',                  '.',                 '', {'branch': 'main', 'cmake': True}),
+    'swanstation':               ('kodi-game/swanstation',      '',                  '.',                 '', {'branch': 'main', 'cmake': True}),
     'tgbdual':                   ('tgbdual-libretro',           'Makefile',          '.',                 'jni', {}),
     'theodore':                  ('Zlika/theodore',             'Makefile',          '.',                 'jni', {}),
     'thepowdertoy':              ('kodi-game/ThePowderToy',     '',                  '',                  '', {'cmake': True, 'binary_dir': 'src'}),


### PR DESCRIPTION
## Description

Fixes https://github.com/kodi-game/game.libretro.swanstation/issues/2

## How has this been tested?

CI run: https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=1847&view=results