### PR TITLE
Add <supports_disc_control> tag for new Disc Manager

### DIFF
--- a/kodi_game_scripting/libretro_ctypes.py
+++ b/kodi_game_scripting/libretro_ctypes.py
@@ -18,9 +18,12 @@
 
 import collections
 import ctypes
+import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 
 from .utils import xstr
 
@@ -54,16 +57,17 @@ class LibretroWrapper:
             self.need_fullpath = retro_system_info.need_fullpath
             self.block_extract = retro_system_info.block_extract
             self.supports_no_game = False
+            self.supports_disc_control = False
 
         def __getitem__(self, item):
             return getattr(self, item)
 
         def __repr__(self):
             return '(name={}, version={}, extensions={}, need_fullpath={},' \
-                   ' block_extract={}, supports_no_game={})'.format(
+                   ' block_extract={}, supports_no_game={}, supports_disc_control={})'.format(
                        self.name, self.version, self.extensions,
                        self.need_fullpath, self.block_extract,
-                       self.supports_no_game)
+                       self.supports_no_game, self.supports_disc_control)
 
     class RetroVariable(ctypes.Structure):
         """ struct libretro_variable """
@@ -71,6 +75,9 @@ class LibretroWrapper:
             ('key', ctypes.c_char_p),
             ('value', ctypes.c_char_p)
         ]
+
+    RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE = 13
+    RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE = 58
 
     def __init__(self, library_path):
         lib = ctypes.cdll.LoadLibrary(library_path)
@@ -108,9 +115,16 @@ class LibretroWrapper:
                     if var.key is None and var.value is None:
                         break
                     outer.variables.append(outer.parse_libretro_variable(var))
+            elif cb_type == self.RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE:
+                outer.system_info.supports_disc_control = True
+            elif cb_type == self.RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE:
+                outer.system_info.supports_disc_control = True
 
         retro_environment_cb = retro_environment_t(retro_environment_cb)
         retro_set_environment(retro_environment_cb)
+
+        self.system_info.supports_disc_control = self.probe_disc_control(
+            library_path)
 
         # opengl linkage
         self.opengl_linkage = self.has_opengl_linkage(library_path)
@@ -135,6 +149,108 @@ class LibretroWrapper:
         return bool(re.search(r'(?:libgl|opengl)',
                               str(ldd_output.stdout, 'utf-8'), re.IGNORECASE))
 
+    @classmethod
+    def probe_disc_control(cls, library_path):
+        """Probe disk control support in a helper subprocess.
+
+        Some cores only register disk control callbacks in retro_init(), and
+        some cores crash inside retro_init(). Running this probe out-of-process
+        prevents a crashing core from aborting the parent while preserving a
+        positive callback result if it fired before the crash.
+        """
+        result_path = None
+        try:
+            with tempfile.NamedTemporaryFile(delete=False) as result_file:
+                result_path = result_file.name
+
+            subprocess.run(
+                [sys.executable, '-m', 'kodi_game_scripting.libretro_ctypes',
+                 '--probe-disc-control', library_path, result_path],
+                check=False)
+            return cls._read_probe_result(result_path)
+        except (OSError, subprocess.SubprocessError):
+            return False
+        finally:
+            if result_path:
+                try:
+                    os.unlink(result_path)
+                except OSError:
+                    pass
+
+    @staticmethod
+    def _read_probe_result(result_path):
+        """Read probe result JSON from helper process."""
+        try:
+            with open(result_path, 'r', encoding='utf-8') as result_file:
+                return bool(json.load(result_file).get('supports_disc_control'))
+        except (OSError, ValueError, AttributeError):
+            return False
+
+
+def _write_probe_result(result_path, supports_disc_control):
+    """Persist probe result to JSON and fsync for crash resilience."""
+    with open(result_path, 'w', encoding='utf-8') as result_file:
+        json.dump({'supports_disc_control': supports_disc_control}, result_file)
+        result_file.flush()
+        os.fsync(result_file.fileno())
+
+
+def probe_disc_control_subprocess(library_path, result_path):
+    """Entrypoint for probing disk control callbacks in an isolated process."""
+    supports_disc_control = False
+
+    lib = ctypes.cdll.LoadLibrary(library_path)
+
+    class RetroSystemInfo(ctypes.Structure):
+        _fields_ = [
+            ('library_name', ctypes.c_char_p),
+            ('library_version', ctypes.c_char_p),
+            ('valid_extensions', ctypes.c_char_p),
+            ('need_fullpath', ctypes.c_bool),
+            ('block_extract', ctypes.c_bool)
+        ]
+
+    retro_get_system_info = lib.retro_get_system_info
+    retro_get_system_info.argtypes = [ctypes.POINTER(RetroSystemInfo)]
+    retro_get_system_info.restype = None
+    system_info = RetroSystemInfo()
+    retro_get_system_info(ctypes.byref(system_info))
+
+    retro_environment_t = ctypes.CFUNCTYPE(ctypes.c_bool, ctypes.c_uint,
+                                           ctypes.c_void_p)
+
+    def retro_environment_cb(cb_type, arg):
+        del arg
+        nonlocal supports_disc_control
+        if cb_type in (
+                LibretroWrapper.RETRO_ENVIRONMENT_SET_DISK_CONTROL_INTERFACE,
+                LibretroWrapper.RETRO_ENVIRONMENT_SET_DISK_CONTROL_EXT_INTERFACE):
+            supports_disc_control = True
+            _write_probe_result(result_path, True)
+        return False
+
+    retro_set_environment = lib.retro_set_environment
+    retro_set_environment.argtypes = [retro_environment_t]
+    retro_set_environment.restype = None
+    retro_environment_cb = retro_environment_t(retro_environment_cb)
+    retro_set_environment(retro_environment_cb)
+
+    retro_init = lib.retro_init
+    retro_init.argtypes = []
+    retro_init.restype = None
+    retro_init()
+
+    retro_deinit = getattr(lib, 'retro_deinit', None)
+    if retro_deinit:
+        retro_deinit.argtypes = []
+        retro_deinit.restype = None
+        retro_deinit()
+
+    _write_probe_result(result_path, supports_disc_control)
+
 
 if __name__ == '__main__':  # pragma: no cover
-    LIB = LibretroWrapper(sys.argv[1])
+    if len(sys.argv) == 4 and sys.argv[1] == '--probe-disc-control':
+        probe_disc_control_subprocess(sys.argv[2], sys.argv[3])
+    else:
+        LIB = LibretroWrapper(sys.argv[1])

--- a/templates/addon/{{ game.addon }}/addon.xml.in.j2
+++ b/templates/addon/{{ game.addon }}/addon.xml.in.j2
@@ -19,6 +19,7 @@
 		<extensions>{{ system_info.extensions | join('|') | escape }}</extensions>
 		<supports_vfs>{{ 'false' if system_info.need_fullpath | default('true') else 'true' }}</supports_vfs>
 		<supports_standalone>{{ system_info.supports_no_game | default('false') | lower }}</supports_standalone>
+		<supports_disc_control>{{ system_info.supports_disc_control | default('false') | lower }}</supports_disc_control>
 		<requires_opengl>{{ 'true' if library.opengl | default('false') else 'false' }}</requires_opengl>
 	</extension>
 	<extension point="xbmc.addon.metadata">


### PR DESCRIPTION
## Description

This adds support for the new `<supports_disc_control>` tag required by the Disc Manager.

## Related PRs:

Disc manager series:

* https://github.com/xbmc/xbmc/pull/27984
* https://github.com/kodi-game/game.libretro/pull/151
* https://github.com/kodi-game/kodi-game-scripting/pull/138
* https://github.com/LibreELEC/LibreELEC.tv/pull/11065

## How has this been tested?

Tested with pcsx-rearmed:

```patch
--- a/game.libretro.pcsx-rearmed/addon.xml.in
+++ b/game.libretro.pcsx-rearmed/addon.xml.in
@@ -18,6 +18,7 @@
 		<extensions>bin|cue|img|mdf|pbp|toc|cbn|m3u|chd|iso|exe</extensions>
 		<supports_vfs>false</supports_vfs>
 		<supports_standalone>false</supports_standalone>
+		<supports_disc_control>true</supports_disc_control>
 		<requires_opengl>false</requires_opengl>
 	</extension>
 	<extension point="xbmc.addon.metadata">
```